### PR TITLE
Ben ghad/swagger api

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -12,3 +12,5 @@ CORS_ORIGINS=http://localhost:3000,http://localhost:3001
 
 # Environment
 ENVIRONMENT=development
+DEBUG=true
+

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -12,6 +12,11 @@ class Settings(BaseSettings):
     # Environment
     ENVIRONMENT: str = "development"
     
+    # API documentation
+    ENABLE_DOCS: bool | None = None
+    ENABLE_REDOC: bool = False
+    OPENAPI_URL: str = "/openapi.json"
+    
     # Supabase
     SUPABASE_URL: str
     SUPABASE_KEY: str
@@ -28,6 +33,37 @@ class Settings(BaseSettings):
     def cors_origins_list(self) -> list[str]:
         """Parse CORS_ORIGINS string into list."""
         return [origin.strip() for origin in self.CORS_ORIGINS.split(",")]
+    
+    @property
+    def is_development(self) -> bool:
+        """Whether the app is running in a development-like environment."""
+        return self.debug or self.ENVIRONMENT.lower() in {"development", "dev", "local"}
+
+    @property
+    def docs_enabled(self) -> bool:
+        """
+        Whether interactive API docs should be enabled.
+
+        Default behavior:
+        - Enabled in development
+        - Disabled in production
+        - Can be overridden via ENABLE_DOCS
+        """
+        if self.ENABLE_DOCS is not None:
+            return self.ENABLE_DOCS
+        return self.is_development
+
+    @property
+    def docs_url(self) -> str | None:
+        """Swagger UI path (None disables Swagger UI)."""
+        return "/docs" if self.docs_enabled else None
+
+    @property
+    def redoc_url(self) -> str | None:
+        """ReDoc path (None disables ReDoc)."""
+        if self.docs_enabled and self.ENABLE_REDOC:
+            return "/redoc"
+        return None
     
     class Config:
         env_file = ".env"

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -13,7 +13,6 @@ class Settings(BaseSettings):
     ENVIRONMENT: str = "development"
     
     # API documentation
-    ENABLE_DOCS: bool | None = None
     ENABLE_REDOC: bool = False
     OPENAPI_URL: str = "/openapi.json"
     
@@ -47,10 +46,7 @@ class Settings(BaseSettings):
         Default behavior:
         - Enabled in development
         - Disabled in production
-        - Can be overridden via ENABLE_DOCS
         """
-        if self.ENABLE_DOCS is not None:
-            return self.ENABLE_DOCS
         return self.is_development
 
     @property

--- a/backend/app/middleware/auth.py
+++ b/backend/app/middleware/auth.py
@@ -4,15 +4,24 @@ Uses Supabase Auth to verify JWT tokens and extract user info.
 """
 
 from fastapi import HTTPException, Depends
-from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from app.services.supabase import get_supabase_client_anon
 from app.models.schemas import User
 
 
-# Security schemes
-security = HTTPBearer()
-security_optional = HTTPBearer(auto_error=False)  # ← auto_error goes here
+# Security schemes for OpenAPI documentation + request auth parsing
+security = HTTPBearer(
+    scheme_name="SupabaseBearerAuth",
+    bearerFormat="JWT",
+    description="Supabase access token. Use: Bearer <access_token>.",
+)
+security_optional = HTTPBearer(
+    auto_error=False,
+    scheme_name="SupabaseBearerAuth",
+    bearerFormat="JWT",
+    description="Optional Supabase access token. Use: Bearer <access_token>.",
+)
 
 
 async def get_current_user(
@@ -57,7 +66,7 @@ async def get_current_user(
 
 
 async def get_optional_user(
-    credentials: HTTPAuthorizationCredentials | None = Depends(security_optional) #Use optional scheme
+    credentials: HTTPAuthorizationCredentials | None = Depends(security_optional)
 ) -> User | None:
     """
     Optionally get the current user if a valid token is provided.

--- a/backend/app/routers/validation.py
+++ b/backend/app/routers/validation.py
@@ -2,8 +2,9 @@
 Validation endpoints for outfit and item compatibility checking.
 """
 import logging
-from fastapi import APIRouter
+from fastapi import APIRouter, Body, status
 from app.models.schemas import (
+    ErrorResponse,
     ValidateItemRequest,
     ValidateItemResponse,
     ValidateOutfitRequest,
@@ -16,8 +17,83 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api", tags=["validation"])
 
 
-@router.post("/validate-item", response_model=ValidateItemResponse)
-async def validate_item_endpoint(request: ValidateItemRequest) -> ValidateItemResponse:
+@router.post(
+    "/validate-item",
+    response_model=ValidateItemResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Validate one item against an outfit",
+    description=(
+        "Checks whether a candidate item is compatible with a base item and current outfit.\n\n"
+        "Validation dimensions include color harmony, formality alignment, aesthetic consistency, "
+        "and category pairing rules."
+    ),
+    responses={
+        200: {
+            "description": "Compatibility result for the candidate item.",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "color_status": "ok",
+                        "formality_status": "ok",
+                        "aesthetic_status": "cohesive",
+                        "pairing_status": "ok",
+                        "warnings": [],
+                    }
+                }
+            },
+        },
+        422: {
+            "description": "Schema validation failed for the request body.",
+        },
+    },
+)
+async def validate_item_endpoint(
+    request: ValidateItemRequest = Body(
+        ...,
+        openapi_examples={
+            "candidate_item_check": {
+                "summary": "Add sneakers to a smart-casual outfit",
+                "value": {
+                    "new_item": {
+                        "color": {
+                            "hex": "#FFFFFF",
+                            "hsl": {"h": 0, "s": 0, "l": 100},
+                            "name": "white",
+                            "is_neutral": True,
+                        },
+                        "category": {"l1": "Shoes", "l2": "Sneakers"},
+                        "formality": 2.0,
+                        "aesthetics": ["Minimalist", "Streetwear"],
+                    },
+                    "base_item": {
+                        "color": {
+                            "hex": "#0B1C2D",
+                            "hsl": {"h": 210, "s": 61, "l": 11},
+                            "name": "navy",
+                            "is_neutral": True,
+                        },
+                        "category": {"l1": "Tops", "l2": "Knitwear"},
+                        "formality": 3.0,
+                        "aesthetics": ["Minimalist"],
+                    },
+                    "current_outfit": [
+                        {
+                            "color": {
+                                "hex": "#2E2E2E",
+                                "hsl": {"h": 0, "s": 0, "l": 18},
+                                "name": "charcoal",
+                                "is_neutral": True,
+                            },
+                            "category": {"l1": "Bottoms", "l2": "Trousers"},
+                            "formality": 3.0,
+                            "aesthetics": ["Minimalist"],
+                        }
+                    ],
+                },
+            }
+        },
+    )
+) -> ValidateItemResponse:
     """Validate a new item against base item and current outfit.
     
     This endpoint checks if a new clothing item is compatible with:
@@ -37,8 +113,89 @@ async def validate_item_endpoint(request: ValidateItemRequest) -> ValidateItemRe
     )
 
 
-@router.post("/validate-outfit", response_model=ValidateOutfitResponse)
-async def validate_outfit_endpoint(request: ValidateOutfitRequest) -> ValidateOutfitResponse:
+@router.post(
+    "/validate-outfit",
+    response_model=ValidateOutfitResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Validate a complete outfit",
+    description=(
+        "Performs full outfit-level validation and scoring.\n\n"
+        "Returns completeness, cohesion score (0-100), warnings, and a color strip for quick UI display."
+    ),
+    responses={
+        200: {
+            "description": "Outfit validation completed successfully.",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "is_complete": True,
+                        "cohesion_score": 87,
+                        "verdict": "Cohesive smart-casual outfit with balanced neutrals.",
+                        "warnings": [],
+                        "color_strip": ["#0B1C2D", "#2E2E2E", "#FFFFFF"],
+                    }
+                }
+            },
+        },
+        422: {
+            "description": "Schema validation failed for the request body.",
+        },
+        500: {
+            "model": ErrorResponse,
+            "description": "Unexpected validation engine error.",
+            "content": {
+                "application/json": {"example": {"detail": "Internal Server Error"}}
+            },
+        },
+    },
+)
+async def validate_outfit_endpoint(
+    request: ValidateOutfitRequest = Body(
+        ...,
+        openapi_examples={
+            "full_outfit_check": {
+                "summary": "3-piece outfit validation",
+                "value": {
+                    "base_item": {
+                        "color": {
+                            "hex": "#0B1C2D",
+                            "hsl": {"h": 210, "s": 61, "l": 11},
+                            "name": "navy",
+                            "is_neutral": True,
+                        },
+                        "category": {"l1": "Tops", "l2": "Blazer"},
+                        "formality": 4.0,
+                        "aesthetics": ["Classic", "Minimalist"],
+                    },
+                    "outfit": [
+                        {
+                            "color": {
+                                "hex": "#3E3E3E",
+                                "hsl": {"h": 0, "s": 0, "l": 24},
+                                "name": "charcoal",
+                                "is_neutral": True,
+                            },
+                            "category": {"l1": "Bottoms", "l2": "Trousers"},
+                            "formality": 4.0,
+                            "aesthetics": ["Classic"],
+                        },
+                        {
+                            "color": {
+                                "hex": "#8B5E3C",
+                                "hsl": {"h": 26, "s": 40, "l": 39},
+                                "name": "brown",
+                                "is_neutral": True,
+                            },
+                            "category": {"l1": "Shoes", "l2": "Loafers"},
+                            "formality": 4.0,
+                            "aesthetics": ["Classic"],
+                        },
+                    ],
+                },
+            }
+        },
+    )
+) -> ValidateOutfitResponse:
     """Validate a complete outfit.
     
     This endpoint performs a comprehensive validation of a complete outfit:

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -1,0 +1,36 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- `src/app/` contains Next.js App Router routes (`page.tsx`, `layout.tsx`) and feature areas like `style/`, `closet/`, and `account/`.
+- `src/app/**/components/` holds route-specific UI; `src/components/` holds shared components (auth, nav, guards).
+- `src/lib/` includes integration and helper modules (`api.ts`, `supabase.ts`, color utilities).
+- `src/store/` contains Zustand state (`styleStore.ts`), and `src/types/` contains shared TypeScript contracts aligned with backend schemas.
+- `public/` stores static assets. Root configs include `next.config.ts`, `tsconfig.json`, `eslint.config.mjs`, and `Dockerfile`.
+
+## Build, Test, and Development Commands
+- `npm ci` installs dependencies from `package-lock.json`.
+- `npm run dev` starts the local dev server on `http://localhost:3000`.
+- `npm run build` creates a production build.
+- `npm run start` serves the production build.
+- `npm run lint` runs ESLint with Next.js + TypeScript rules.
+- Optional Docker flow: `docker build -t siy-frontend .` (pass required `NEXT_PUBLIC_*` values at build/run time).
+
+## Coding Style & Naming Conventions
+- Use TypeScript with strict typing (`tsconfig.json` has `strict: true`).
+- Use the `@/*` alias for imports from `src/` when practical.
+- Follow existing formatting: 2-space indentation and semicolon-free style.
+- Name React component files in `PascalCase` (example: `AuthModal.tsx`).
+- Use `camelCase` for utilities, store functions, and variables (example: `colorUtils.ts`, `useStyleStore`).
+- Keep route directory names lowercase to match URL segments.
+- Use Tailwind classes and theme tokens defined in `src/app/global.css`.
+
+## Testing Guidelines
+- No automated test runner is configured currently.
+- Before opening a PR, run `npm run lint` and manually verify core flows (`/`, `/style`, `/closet`, auth modal/login).
+- If you add tests, use `*.test.ts` or `*.test.tsx` naming and place tests near related code or under `src/__tests__/`.
+
+## Commit & Pull Request Guidelines
+- Prefer short, specific, imperative commit subjects (example: `fix duplicate item validation`).
+- Avoid vague commit messages such as `nit` or `test fixes`.
+- PRs should include: summary of changes, how to verify, linked issue (if available), and screenshots/GIFs for UI changes.
+- Call out environment/config updates explicitly (for example `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_API_URL`).

--- a/frontend/docs/component-audit.md
+++ b/frontend/docs/component-audit.md
@@ -1,0 +1,51 @@
+# Component Duplication Audit
+
+## Scope
+Audit date: February 28, 2026
+
+Scanned directories:
+- `src/components`
+- `src/app/style/components`
+- `src/app/closet/components`
+- `src/app/closet/page.tsx`
+
+## Duplication Findings
+
+1. Modal shell duplicated across at least 5 files with near-identical backdrop, panel, close button, and z-index layout.
+- `src/app/closet/components/ItemDetailModal.tsx`
+- `src/app/closet/components/OutfitDetailModal.tsx`
+- `src/app/style/components/ItemDetailModal.tsx`
+- `src/app/style/components/TryOnModal.tsx`
+- `src/app/style/components/TryonOutfitModal.tsx`
+
+2. Repeated button variants (white primary, transparent secondary, destructive) across pages and modal footers.
+- `src/components/AuthModal.tsx`
+- `src/app/closet/page.tsx`
+- `src/app/style/components/SummaryStep.tsx`
+- `src/app/style/components/MetadataStep.tsx`
+
+3. Repeated card wrappers for item/outfit thumbnails and metadata.
+- `src/app/closet/page.tsx`
+- `src/app/style/components/SummaryStep.tsx`
+- `src/app/closet/components/OutfitDetailModal.tsx`
+
+4. Label/input styling repeated in auth and metadata forms.
+- `src/components/AuthModal.tsx`
+- `src/app/style/components/MetadataStep.tsx`
+- `src/app/style/components/shared/ColorSelector.tsx`
+
+5. Loading skeleton/spinner patterns are inconsistent and mostly hand-coded per page.
+- `src/app/closet/page.tsx`
+- `src/app/closet/components/OutfitDetailModal.tsx`
+- `src/app/style/components/SummaryStep.tsx`
+
+## Standardization Implemented
+
+Shared UI primitives were introduced in `src/components/ui` and integrated into high-duplication surfaces:
+- `Button`: used in `AuthModal`, closet page toggle/retry, modal actions.
+- `Card` + card variants: used in closet page and suggestion panel.
+- `Modal` + `ConfirmationModal`: used in auth, closet detail modals, style detail and try-on modals.
+- `Input` (`TextInput`, `FileUploadInput`): used in auth, metadata optional fields, image upload zone.
+- `Badge` variants: used for ownership/status, harmony tags, base item labels.
+- `Skeleton`: used for closet loading and outfit detail loading state.
+

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -2,6 +2,9 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: "standalone",
+  turbopack: {
+    root: process.cwd(),
+  },
 };
 
 export default nextConfig;

--- a/frontend/src/app/closet/components/ItemDetailModal.tsx
+++ b/frontend/src/app/closet/components/ItemDetailModal.tsx
@@ -1,9 +1,17 @@
 'use client'
 
 import { useState } from 'react'
-import { X, ExternalLink, Tag, DollarSign, Shirt, Calendar, ShoppingBag, Trash2 } from 'lucide-react'
+import { ExternalLink, Tag, DollarSign, Shirt, Calendar, ShoppingBag, Trash2 } from 'lucide-react'
 import type { ClothingItemResponse } from '@/types'
-import { FORMALITY_LEVELS } from '@/types'
+import {
+  Badge,
+  Button,
+  CategoryBadge,
+  ConfirmationModal,
+  FormalityBadge,
+  Modal,
+  StatusBadge,
+} from '@/components/ui'
 
 interface ItemDetailModalProps {
   item: ClothingItemResponse
@@ -14,15 +22,13 @@ interface ItemDetailModalProps {
 export default function ItemDetailModal({ item, onClose, onDelete }: ItemDetailModalProps) {
   const [isDeleting, setIsDeleting] = useState(false)
   const [showConfirm, setShowConfirm] = useState(false)
-  
-  const formalityLabel = FORMALITY_LEVELS[item.formality as keyof typeof FORMALITY_LEVELS] || item.formality
 
   const formatDate = (dateString: string) => {
     try {
       return new Date(dateString).toLocaleDateString('en-US', {
         month: 'long',
         day: 'numeric',
-        year: 'numeric'
+        year: 'numeric',
       })
     } catch {
       return dateString
@@ -32,211 +38,139 @@ export default function ItemDetailModal({ item, onClose, onDelete }: ItemDetailM
   const handleDelete = async () => {
     if (!onDelete) return
     setIsDeleting(true)
+
     try {
       await onDelete(item.id)
       onClose()
     } catch (error) {
       console.error('Failed to delete item:', error)
+    } finally {
       setIsDeleting(false)
       setShowConfirm(false)
     }
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-      {/* Backdrop */}
-      <div 
-        className="absolute inset-0 bg-black/80 backdrop-blur-sm"
-        onClick={onClose}
-      />
-      
-      {/* Modal */}
-      <div className="relative bg-primary-900 border border-primary-700 rounded-xl w-full max-w-lg overflow-hidden flex flex-col max-h-[90vh]">
-        {/* Header */}
-        <div className="flex items-center justify-between p-4 border-b border-primary-800 shrink-0">
-          <div>
-            <h3 className="text-lg font-bold uppercase tracking-widest text-white">
-              {item.category.l2}
-            </h3>
-            <span className="text-[10px] font-bold uppercase tracking-wider text-neutral-500">
-              {item.category.l1}
-            </span>
+    <>
+      <Modal
+        isOpen={true}
+        onClose={onClose}
+        title={item.category.l2}
+        description={item.category.l1}
+        size="md"
+        footer={
+          <div className="flex gap-[var(--space-3)]">
+            <Button variant="secondary" className="flex-1" onClick={onClose}>
+              Close
+            </Button>
+            {onDelete && (
+              <Button
+                variant="danger"
+                className="flex-1"
+                onClick={() => setShowConfirm(true)}
+                leftIcon={<Trash2 size={14} aria-hidden="true" />}
+              >
+                Delete
+              </Button>
+            )}
           </div>
-          <button onClick={onClose} className="p-1 text-neutral-500 hover:text-white transition-colors">
-            <X size={20} />
-          </button>
-        </div>
-
-        {/* Scrollable Content */}
-        <div className="overflow-y-auto p-6 scrollbar-hide">
-          {/* Image */}
-          <div className="aspect-[3/4] bg-primary-800 rounded-lg overflow-hidden border border-primary-700 mb-6 relative">
+        }
+      >
+        <div className="space-y-[var(--space-6)]">
+          <div className="relative mb-[var(--space-2)] aspect-[3/4] overflow-hidden rounded-[var(--radius-lg)] border border-primary-700 bg-primary-800">
             {item.image_url ? (
-              <img src={item.image_url} alt={item.category.l2} className="w-full h-full object-contain" />
+              <img src={item.image_url} alt={item.category.l2} className="h-full w-full object-contain" />
             ) : (
-              <div className="w-full h-full flex items-center justify-center text-neutral-600">
-                <Shirt size={48} strokeWidth={1} />
+              <div className="flex h-full w-full items-center justify-center text-neutral-600">
+                <Shirt size={48} strokeWidth={1} aria-hidden="true" />
               </div>
             )}
-            
-            {/* Color Pill */}
-            <div className="absolute bottom-3 right-3 flex items-center gap-2 bg-primary-900/90 backdrop-blur px-3 py-1.5 rounded-full border border-primary-700 shadow-sm">
-              <div 
-                className="w-3 h-3 rounded-full ring-1 ring-white/20" 
-                style={{ backgroundColor: item.color.hex }} 
-              />
-              <span className="text-[10px] uppercase font-bold text-white tracking-wider">
-                {item.color.name}
-              </span>
+
+            <div className="absolute right-[var(--space-3)] top-[var(--space-3)]">
+              <StatusBadge status={item.ownership} />
             </div>
 
-            {/* Ownership Badge */}
-            <div className={`absolute top-3 right-3 px-2.5 py-1 rounded text-[10px] font-bold uppercase tracking-wider ${
-              item.ownership === 'owned' 
-                ? 'bg-success-500/20 text-success-400 border border-success-500/30' 
-                : 'bg-accent-500/20 text-accent-400 border border-accent-500/30'
-            }`}>
-              {item.ownership === 'owned' ? 'Owned' : 'Wishlist'}
-            </div>
-          </div>
-
-          {/* Details Grid */}
-          <div className="grid grid-cols-2 gap-6 mb-6">
-            <div>
-              <label className="block text-[10px] uppercase font-bold tracking-widest text-neutral-500 mb-1">
-                Formality
-              </label>
-              <p className="text-sm font-medium text-white">{formalityLabel}</p>
-            </div>
-            <div>
-              <label className="block text-[10px] uppercase font-bold tracking-widest text-neutral-500 mb-1">
-                Color
-              </label>
-              <div className="flex items-center gap-2">
-                <div 
-                  className="w-4 h-4 rounded-full border border-primary-600" 
-                  style={{ backgroundColor: item.color.hex }} 
+            <div className="absolute bottom-[var(--space-3)] right-[var(--space-3)] rounded-full border border-primary-700 bg-primary-900/90 px-[var(--space-3)] py-[var(--space-1)] backdrop-blur">
+              <div className="flex items-center gap-[var(--space-2)]">
+                <div
+                  className="h-3 w-3 rounded-full border border-primary-700"
+                  style={{ backgroundColor: item.color.hex }}
+                  aria-hidden="true"
                 />
-                <p className="text-sm font-medium text-white capitalize">{item.color.name}</p>
-                {item.color.is_neutral && (
-                  <span className="text-[9px] px-1.5 py-0.5 bg-neutral-700 text-neutral-300 rounded uppercase">Neutral</span>
-                )}
+                <span className="text-[10px] font-bold uppercase tracking-wider text-white">{item.color.name}</span>
               </div>
             </div>
           </div>
 
-          {/* Aesthetics */}
+          <div className="flex flex-wrap gap-[var(--space-2)]">
+            <FormalityBadge level={item.formality} />
+            <CategoryBadge category={item.category.l1} />
+            {item.color.is_neutral && <Badge tone="neutral">Neutral</Badge>}
+          </div>
+
           {item.aesthetics.length > 0 && (
-            <div className="mb-6">
-              <label className="block text-[10px] uppercase font-bold tracking-widest text-neutral-500 mb-2">
-                Aesthetics
-              </label>
-              <div className="flex flex-wrap gap-2">
-                {item.aesthetics.map(tag => (
-                  <span key={tag} className="px-2.5 py-1 bg-primary-800 border border-primary-700 rounded text-[10px] uppercase tracking-wider text-neutral-300">
+            <div>
+              <p className="mb-[var(--space-2)] text-[10px] font-bold uppercase tracking-widest text-neutral-500">Aesthetics</p>
+              <div className="flex flex-wrap gap-[var(--space-2)]">
+                {item.aesthetics.map((tag) => (
+                  <Badge key={tag} tone="neutral">
                     {tag}
-                  </span>
+                  </Badge>
                 ))}
               </div>
             </div>
           )}
 
-          {/* Optional Info */}
-          <div className="pt-6 border-t border-primary-800 space-y-3">
+          <div className="space-y-[var(--space-3)] border-t border-primary-800 pt-[var(--space-4)]">
             {item.brand && (
-              <div className="flex items-center gap-3 text-sm text-neutral-300">
-                <Tag size={14} className="text-neutral-500 flex-shrink-0" />
+              <div className="flex items-center gap-[var(--space-3)] text-sm text-neutral-300">
+                <Tag size={14} className="shrink-0 text-neutral-500" aria-hidden="true" />
                 <span>{item.brand}</span>
               </div>
             )}
             {item.price !== null && item.price !== undefined && (
-              <div className="flex items-center gap-3 text-sm text-neutral-300">
-                <DollarSign size={14} className="text-neutral-500 flex-shrink-0" />
+              <div className="flex items-center gap-[var(--space-3)] text-sm text-neutral-300">
+                <DollarSign size={14} className="shrink-0 text-neutral-500" aria-hidden="true" />
                 <span>${item.price.toFixed(2)}</span>
               </div>
             )}
             {item.source_url && (
-              <div className="flex items-center gap-3 text-sm">
-                <ExternalLink size={14} className="text-neutral-500 flex-shrink-0" />
-                <a 
-                  href={item.source_url} 
-                  target="_blank" 
+              <div className="flex items-center gap-[var(--space-3)] text-sm">
+                <ExternalLink size={14} className="shrink-0 text-neutral-500" aria-hidden="true" />
+                <a
+                  href={item.source_url}
+                  target="_blank"
                   rel="noopener noreferrer"
-                  className="text-accent-500 hover:text-accent-400 hover:underline truncate"
+                  className="truncate text-accent-500 hover:text-accent-400 hover:underline"
                 >
                   View Source
                 </a>
               </div>
             )}
-            <div className="flex items-center gap-3 text-sm text-neutral-300">
-              <ShoppingBag size={14} className="text-neutral-500 flex-shrink-0" />
+            <div className="flex items-center gap-[var(--space-3)] text-sm text-neutral-300">
+              <ShoppingBag size={14} className="shrink-0 text-neutral-500" aria-hidden="true" />
               <span className="capitalize">{item.ownership}</span>
             </div>
-            <div className="flex items-center gap-3 text-sm text-neutral-400">
-              <Calendar size={14} className="text-neutral-500 flex-shrink-0" />
+            <div className="flex items-center gap-[var(--space-3)] text-sm text-neutral-400">
+              <Calendar size={14} className="shrink-0 text-neutral-500" aria-hidden="true" />
               <span>Added {formatDate(item.created_at)}</span>
             </div>
           </div>
         </div>
+      </Modal>
 
-        {/* Footer */}
-        <div className="p-4 border-t border-primary-800 bg-primary-900 shrink-0">
-          {showConfirm ? (
-            <div className="space-y-3">
-              <p className="text-sm text-neutral-300 text-center">
-                Delete this item? This cannot be undone.
-              </p>
-              <div className="flex gap-2">
-                <button
-                  onClick={() => setShowConfirm(false)}
-                  disabled={isDeleting}
-                  className="flex-1 px-4 py-3 bg-primary-800 text-white hover:bg-primary-700
-                    text-xs font-bold uppercase tracking-widest transition-all rounded-lg border border-primary-700
-                    disabled:opacity-50"
-                >
-                  Cancel
-                </button>
-                <button
-                  onClick={handleDelete}
-                  disabled={isDeleting}
-                  className="flex-1 px-4 py-3 bg-error-500 text-white hover:bg-error-600
-                    text-xs font-bold uppercase tracking-widest transition-all rounded-lg
-                    disabled:opacity-50 flex items-center justify-center gap-2"
-                >
-                  {isDeleting ? (
-                    <div className="animate-spin w-4 h-4 border-2 border-white border-t-transparent rounded-full" />
-                  ) : (
-                    <>
-                      <Trash2 size={14} />
-                      Delete
-                    </>
-                  )}
-                </button>
-              </div>
-            </div>
-          ) : (
-            <div className="flex gap-2">
-              <button
-                onClick={onClose}
-                className="flex-1 px-4 py-3 bg-primary-800 text-white hover:bg-primary-700
-                  text-xs font-bold uppercase tracking-widest transition-all rounded-lg border border-primary-700"
-              >
-                Close
-              </button>
-              {onDelete && (
-                <button
-                  onClick={() => setShowConfirm(true)}
-                  className="px-4 py-3 bg-primary-800 text-error-400 hover:bg-error-500/20 hover:text-error-300
-                    text-xs font-bold uppercase tracking-widest transition-all rounded-lg border border-primary-700
-                    hover:border-error-500/50"
-                >
-                  <Trash2 size={16} />
-                </button>
-              )}
-            </div>
-          )}
-        </div>
-      </div>
-    </div>
+      {onDelete && (
+        <ConfirmationModal
+          isOpen={showConfirm}
+          onClose={() => setShowConfirm(false)}
+          onConfirm={handleDelete}
+          isConfirming={isDeleting}
+          title="Delete Item"
+          description="Delete this item? This cannot be undone."
+          confirmLabel="Delete"
+          tone="danger"
+        />
+      )}
+    </>
   )
 }

--- a/frontend/src/app/global.css
+++ b/frontend/src/app/global.css
@@ -3,6 +3,31 @@
 :root {
   --background: #101518; /* primary-900 */
   --foreground: #ffffff; /* neutral-50 */
+
+  /* Spacing tokens */
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.25rem;
+  --space-6: 1.5rem;
+  --space-8: 2rem;
+  --space-10: 2.5rem;
+  --space-12: 3rem;
+
+  /* Sizing tokens */
+  --size-control-sm: 2rem;
+  --size-control-md: 2.75rem;
+  --size-control-lg: 3.25rem;
+  --size-icon-sm: 0.875rem;
+  --size-icon-md: 1rem;
+  --size-icon-lg: 1.25rem;
+
+  /* Radius tokens */
+  --radius-sm: 0.375rem;
+  --radius-md: 0.625rem;
+  --radius-lg: 0.875rem;
+  --radius-xl: 1rem;
 }
 
 @theme {

--- a/frontend/src/app/style/components/ItemDetailModal.tsx
+++ b/frontend/src/app/style/components/ItemDetailModal.tsx
@@ -1,8 +1,9 @@
 'use client'
 
-import { X, ExternalLink, Sparkles, Tag, DollarSign, Shirt } from 'lucide-react'
+import { ExternalLink, Sparkles, Tag, DollarSign, Shirt } from 'lucide-react'
 import type { ClothingItemCreate } from '@/types'
 import { FORMALITY_LEVELS } from '@/types'
+import { Badge, Button, Modal } from '@/components/ui'
 
 interface ItemDetailModalProps {
   item: ClothingItemCreate
@@ -24,146 +25,108 @@ export default function ItemDetailModal({
   const formalityLabel = FORMALITY_LEVELS[item.formality as keyof typeof FORMALITY_LEVELS] || item.formality
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-      {/* Backdrop */}
-      <div 
-        className="absolute inset-0 bg-black/80 backdrop-blur-sm"
-        onClick={onClose}
-      />
-      
-      {/* Modal */}
-      <div className="relative bg-primary-900 border border-primary-700 rounded-xl w-full max-w-lg overflow-hidden flex flex-col max-h-[90vh]">
-        {/* Header */}
-        <div className="flex items-center justify-between p-4 border-b border-primary-800 shrink-0">
-          <div>
-            <h3 className="text-lg font-bold uppercase tracking-widest text-white">
-              {item.category.l2}
-            </h3>
-            {isBase && (
-              <span className="text-[10px] font-bold uppercase tracking-wider text-accent-500 bg-accent-500/10 px-2 py-0.5 rounded-full">
-                Base Item
-              </span>
-            )}
-          </div>
-          <button onClick={onClose} className="p-1 text-neutral-500 hover:text-white">
-            <X size={20} />
-          </button>
-        </div>
-
-        {/* Scrollable Content */}
-        <div className="overflow-y-auto p-6 scrollbar-hide">
-          {/* Image */}
-          <div className="aspect-[3/4] bg-primary-800 rounded-lg overflow-hidden border border-primary-700 mb-6 relative">
-            {item.image_url ? (
-              <img src={item.image_url} alt="Item" className="w-full h-full object-contain" />
-            ) : (
-              <div className="w-full h-full flex items-center justify-center text-neutral-600">
-                <Shirt size={48} strokeWidth={1} />
-              </div>
-            )}
-            
-            {/* Color Pill */}
-            <div className="absolute bottom-3 right-3 flex items-center gap-2 bg-primary-900/90 backdrop-blur px-3 py-1.5 rounded-full border border-primary-700 shadow-sm">
-              <div 
-                className="w-3 h-3 rounded-full ring-1 ring-white/20" 
-                style={{ backgroundColor: item.color.hex }} 
-              />
-              <span className="text-[10px] uppercase font-bold text-white tracking-wider">
-                {item.color.name}
-              </span>
-            </div>
-          </div>
-
-          {/* Details Grid */}
-          <div className="grid grid-cols-2 gap-6 mb-6">
-            <div>
-              <label className="block text-[10px] uppercase font-bold tracking-widest text-neutral-500 mb-1">
-                Formality
-              </label>
-              <p className="text-sm font-medium text-white">{formalityLabel}</p>
-            </div>
-            <div>
-              <label className="block text-[10px] uppercase font-bold tracking-widest text-neutral-500 mb-1">
-                Category
-              </label>
-              <p className="text-sm font-medium text-white">{item.category.l1} / {item.category.l2}</p>
-            </div>
-          </div>
-
-          {/* Aesthetics */}
-          {item.aesthetics.length > 0 && (
-            <div className="mb-6">
-              <label className="block text-[10px] uppercase font-bold tracking-widest text-neutral-500 mb-2">
-                Aesthetics
-              </label>
-              <div className="flex flex-wrap gap-2">
-                {item.aesthetics.map(tag => (
-                  <span key={tag} className="px-2.5 py-1 bg-primary-800 border border-primary-700 rounded text-[10px] uppercase tracking-wider text-neutral-300">
-                    {tag}
-                  </span>
-                ))}
-              </div>
-            </div>
-          )}
-
-          {/* Optional Info */}
-          {(item.brand || item.price || item.source_url) && (
-            <div className="pt-6 border-t border-primary-800 space-y-3">
-              {item.brand && (
-                <div className="flex items-center gap-3 text-sm text-neutral-300">
-                  <Tag size={14} className="text-neutral-500" />
-                  <span>{item.brand}</span>
-                </div>
-              )}
-              {item.price && (
-                <div className="flex items-center gap-3 text-sm text-neutral-300">
-                  <DollarSign size={14} className="text-neutral-500" />
-                  <span>${item.price.toFixed(2)}</span>
-                </div>
-              )}
-              {item.source_url && (
-                <div className="flex items-center gap-3 text-sm">
-                  <ExternalLink size={14} className="text-neutral-500" />
-                  <a 
-                    href={item.source_url} 
-                    target="_blank" 
-                    rel="noopener noreferrer"
-                    className="text-accent-500 hover:text-accent-400 hover:underline truncate"
-                  >
-                    View Source
-                  </a>
-                </div>
-              )}
-            </div>
-          )}
-        </div>
-
-        {/* Footer Actions */}
-        <div className="p-4 border-t border-primary-800 bg-primary-900 shrink-0">
+    <Modal
+      isOpen={true}
+      onClose={onClose}
+      title={item.category.l2}
+      size="md"
+      footer={
+        <>
           {tryOnUrl && onViewTryOn ? (
-            <button
+            <Button
               onClick={onViewTryOn}
-              className="w-full flex items-center justify-center gap-2 px-4 py-3 
-                bg-accent-500/10 text-accent-500 border border-accent-500/50
-                hover:bg-accent-500 hover:text-primary-900
-                text-xs font-bold uppercase tracking-widest transition-all rounded-lg"
+              variant="secondary"
+              fullWidth
+              leftIcon={<Sparkles size={16} aria-hidden="true" />}
             >
-              <Sparkles size={16} />
               View Try-On Result
-            </button>
+            </Button>
           ) : onTryOn ? (
-            <button
-              onClick={onTryOn}
-              className="w-full flex items-center justify-center gap-2 px-4 py-3 
-                bg-white text-primary-900 hover:bg-neutral-200
-                text-xs font-bold uppercase tracking-widest transition-all rounded-lg"
-            >
-              <Sparkles size={16} />
+            <Button onClick={onTryOn} fullWidth leftIcon={<Sparkles size={16} aria-hidden="true" />}>
               Try On Item
-            </button>
+            </Button>
           ) : null}
+        </>
+      }
+    >
+      <div className="space-y-[var(--space-6)]">
+        <div className="relative aspect-[3/4] overflow-hidden rounded-[var(--radius-lg)] border border-primary-700 bg-primary-800">
+          {item.image_url ? (
+            <img src={item.image_url} alt="Item" className="h-full w-full object-contain" />
+          ) : (
+            <div className="flex h-full w-full items-center justify-center text-neutral-600">
+              <Shirt size={48} strokeWidth={1} aria-hidden="true" />
+            </div>
+          )}
+
+          <div className="absolute bottom-[var(--space-3)] right-[var(--space-3)] flex items-center gap-[var(--space-2)] rounded-full border border-primary-700 bg-primary-900/90 px-[var(--space-3)] py-[var(--space-1)] shadow-sm backdrop-blur">
+            <div
+              className="h-3 w-3 rounded-full ring-1 ring-white/20"
+              style={{ backgroundColor: item.color.hex }}
+              aria-hidden="true"
+            />
+            <span className="text-[10px] font-bold uppercase tracking-wider text-white">{item.color.name}</span>
+          </div>
+
+          {isBase && <Badge className="absolute right-[var(--space-3)] top-[var(--space-3)]">Base Item</Badge>}
         </div>
+
+        <div className="grid grid-cols-2 gap-[var(--space-6)]">
+          <div>
+            <p className="mb-[var(--space-1)] text-[10px] font-bold uppercase tracking-widest text-neutral-500">Formality</p>
+            <p className="text-sm font-medium text-white">{formalityLabel}</p>
+          </div>
+          <div>
+            <p className="mb-[var(--space-1)] text-[10px] font-bold uppercase tracking-widest text-neutral-500">Category</p>
+            <p className="text-sm font-medium text-white">
+              {item.category.l1} / {item.category.l2}
+            </p>
+          </div>
+        </div>
+
+        {item.aesthetics.length > 0 && (
+          <div>
+            <p className="mb-[var(--space-2)] text-[10px] font-bold uppercase tracking-widest text-neutral-500">Aesthetics</p>
+            <div className="flex flex-wrap gap-[var(--space-2)]">
+              {item.aesthetics.map((tag) => (
+                <Badge key={tag} tone="neutral">
+                  {tag}
+                </Badge>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {(item.brand || item.price || item.source_url) && (
+          <div className="space-y-[var(--space-3)] border-t border-primary-800 pt-[var(--space-4)]">
+            {item.brand && (
+              <div className="flex items-center gap-[var(--space-3)] text-sm text-neutral-300">
+                <Tag size={14} className="text-neutral-500" aria-hidden="true" />
+                <span>{item.brand}</span>
+              </div>
+            )}
+            {item.price !== null && item.price !== undefined && (
+              <div className="flex items-center gap-[var(--space-3)] text-sm text-neutral-300">
+                <DollarSign size={14} className="text-neutral-500" aria-hidden="true" />
+                <span>${item.price.toFixed(2)}</span>
+              </div>
+            )}
+            {item.source_url && (
+              <div className="flex items-center gap-[var(--space-3)] text-sm">
+                <ExternalLink size={14} className="text-neutral-500" aria-hidden="true" />
+                <a
+                  href={item.source_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="truncate text-accent-500 hover:text-accent-400 hover:underline"
+                >
+                  View Source
+                </a>
+              </div>
+            )}
+          </div>
+        )}
       </div>
-    </div>
+    </Modal>
   )
 }

--- a/frontend/src/app/style/components/MetadataStep.tsx
+++ b/frontend/src/app/style/components/MetadataStep.tsx
@@ -4,6 +4,7 @@ import { useCallback, useState } from 'react'
 import { useStyleStore } from '@/store/styleStore'
 import { ArrowLeft, ArrowRight, ChevronDown, Tag, DollarSign, Link as LinkIcon } from 'lucide-react'
 import { CATEGORY_TAXONOMY } from '@/types'
+import { TextInput } from '@/components/ui'
 import CategorySelector from './shared/CategorySelector'
 import FormalitySlider from './shared/FormalitySlider'
 import AestheticsSelector from './shared/AestheticsSelector'
@@ -138,60 +139,36 @@ export default function MetadataStep() {
               <div className="mt-6 space-y-5 animate-in fade-in slide-in-from-top-2 duration-300">
                 
                 {/* Brand */}
-                <div>
-                  <label className="block text-[10px] uppercase font-bold tracking-widest text-neutral-500 mb-2">
-                    Brand
-                  </label>
-                  <div className="relative">
-                    <Tag size={14} className="absolute left-4 top-1/2 -translate-y-1/2 text-neutral-600" />
-                    <input
-                      type="text"
-                      value={brand}
-                      onChange={(e) => setBrand(e.target.value)}
-                      placeholder="e.g. Nike, Zara, Uniqlo"
-                      className="w-full pl-11 pr-4 py-3 bg-primary-800 border border-primary-700 text-white text-sm
-                        placeholder-neutral-600 focus:outline-none focus:border-accent-500 transition-colors"
-                    />
-                  </div>
-                </div>
+                <TextInput
+                  label="Brand"
+                  type="text"
+                  value={brand}
+                  onChange={(e) => setBrand(e.target.value)}
+                  placeholder="e.g. Nike, Zara, Uniqlo"
+                  leftIcon={<Tag size={14} aria-hidden="true" />}
+                />
 
                 {/* Price */}
-                <div>
-                  <label className="block text-[10px] uppercase font-bold tracking-widest text-neutral-500 mb-2">
-                    Price
-                  </label>
-                  <div className="relative">
-                    <DollarSign size={14} className="absolute left-4 top-1/2 -translate-y-1/2 text-neutral-600" />
-                    <input
-                      type="number"
-                      value={price}
-                      onChange={(e) => setPrice(e.target.value)}
-                      placeholder="0.00"
-                      min="0"
-                      step="0.01"
-                      className="w-full pl-11 pr-4 py-3 bg-primary-800 border border-primary-700 text-white text-sm
-                        placeholder-neutral-600 focus:outline-none focus:border-accent-500 transition-colors"
-                    />
-                  </div>
-                </div>
+                <TextInput
+                  label="Price"
+                  type="number"
+                  value={price}
+                  onChange={(e) => setPrice(e.target.value)}
+                  placeholder="0.00"
+                  min="0"
+                  step="0.01"
+                  leftIcon={<DollarSign size={14} aria-hidden="true" />}
+                />
 
                 {/* Source URL */}
-                <div>
-                  <label className="block text-[10px] uppercase font-bold tracking-widest text-neutral-500 mb-2">
-                    Source URL
-                  </label>
-                  <div className="relative">
-                    <LinkIcon size={14} className="absolute left-4 top-1/2 -translate-y-1/2 text-neutral-600" />
-                    <input
-                      type="url"
-                      value={sourceUrl}
-                      onChange={(e) => setSourceUrl(e.target.value)}
-                      placeholder="https://..."
-                      className="w-full pl-11 pr-4 py-3 bg-primary-800 border border-primary-700 text-white text-sm
-                        placeholder-neutral-600 focus:outline-none focus:border-accent-500 transition-colors"
-                    />
-                  </div>
-                </div>
+                <TextInput
+                  label="Source URL"
+                  type="url"
+                  value={sourceUrl}
+                  onChange={(e) => setSourceUrl(e.target.value)}
+                  placeholder="https://..."
+                  leftIcon={<LinkIcon size={14} aria-hidden="true" />}
+                />
               </div>
             )}
           </div>

--- a/frontend/src/app/style/components/TryonOutfitModal.tsx
+++ b/frontend/src/app/style/components/TryonOutfitModal.tsx
@@ -1,12 +1,13 @@
 'use client'
 
 import { useState } from 'react'
-import { X, Sparkles } from 'lucide-react'
+import { Sparkles } from 'lucide-react'
 import { tryOnOutfit, uploadUserPhoto, uploadItemImage } from '@/lib/api'
 import { useStyleStore } from '@/store/styleStore'
-import type { ClothingItemCreate } from '@/types'
+import type { ClothingItemCreate, TryOnOutfitRequest } from '@/types'
 import ImageUploadZone from './shared/ImageUploadZone'
 import TryOnResult from './shared/TryOnResult'
+import { Button, Card, Modal } from '@/components/ui'
 
 interface TryOnOutfitModalProps {
   items: Array<{
@@ -15,13 +16,11 @@ interface TryOnOutfitModalProps {
   }>
   token: string
   onClose: () => void
-  // 1. Add this prop
   onComplete?: (url: string) => void
 }
 
 type ModalStep = 'upload' | 'generating' | 'result'
 
-// 2. Add onComplete to destructuring
 export default function TryOnOutfitModal({ items, token, onClose, onComplete }: TryOnOutfitModalProps) {
   const { getBaseItem, setTryOnResult } = useStyleStore()
   const [step, setStep] = useState<ModalStep>('upload')
@@ -36,43 +35,40 @@ export default function TryOnOutfitModal({ items, token, onClose, onComplete }: 
     setError(null)
 
     try {
-      // 1. Upload user photo
       const userPhotoUrl = await uploadUserPhoto(userPhotoFile, token)
-      
-      // 2. Upload item images and prepare payload
-      const itemImages: [string, any][] = await Promise.all(
-        items.map(async (i) => {
-          let itemImageUrl = i.item.image_url || ''
-          
-          // If the URL is a blob URL, upload the image blob
+
+      const itemImages: TryOnOutfitRequest['item_images'] = await Promise.all(
+        items.map(async (entry) => {
+          let itemImageUrl = entry.item.image_url || ''
+
           if (itemImageUrl.startsWith('blob:')) {
-            itemImageUrl = await uploadItemImage(i.imageBlob, token)
+            itemImageUrl = await uploadItemImage(entry.imageBlob, token)
           }
-          
+
           return [
             itemImageUrl,
             {
-              color: i.item.color,
-              category: i.item.category,
-              formality: i.item.formality,
-              aesthetics: i.item.aesthetics,
-            }
-          ] as [string, any]
+              color: entry.item.color,
+              category: entry.item.category,
+              formality: entry.item.formality,
+              aesthetics: entry.item.aesthetics,
+            },
+          ]
         })
       )
-      
-      // 3. Call API
-      const response = await tryOnOutfit({
-        user_photo_url: userPhotoUrl,
-        item_images: itemImages
-      }, token)
 
-      // 4. Pass the generated URL back to the parent (SummaryStep) immediately
+      const response = await tryOnOutfit(
+        {
+          user_photo_url: userPhotoUrl,
+          item_images: itemImages,
+        },
+        token
+      )
+
       if (response.generated_image_url && onComplete) {
         onComplete(response.generated_image_url)
       }
 
-      // Save to store FIRST, before updating UI
       const baseItem = getBaseItem()
       if (baseItem?.category?.l1 && response.generated_image_url) {
         setTryOnResult(baseItem.category.l1, response.generated_image_url)
@@ -81,7 +77,6 @@ export default function TryOnOutfitModal({ items, token, onClose, onComplete }: 
       setResultUrl(response.generated_image_url || null)
       setProcessingTime(response.processing_time || null)
       setStep('result')
-      
     } catch (err) {
       console.error('Outfit Try-on failed:', err)
       setError('Failed to generate outfit try-on. Please try again.')
@@ -96,72 +91,87 @@ export default function TryOnOutfitModal({ items, token, onClose, onComplete }: 
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-      <div className="absolute inset-0 bg-black/80 backdrop-blur-sm" onClick={onClose} />
-      
-      <div className="relative bg-primary-900 border border-primary-700 rounded-xl w-full max-w-lg overflow-hidden">
-        <div className="flex items-center justify-between p-4 border-b border-primary-800">
-          <h3 className="text-lg font-bold uppercase tracking-widest text-white">Try On Full Outfit</h3>
-          <button onClick={onClose} className="p-1 text-neutral-500 hover:text-white"><X size={20} /></button>
-        </div>
-
-        <div className="p-6">
-          {step === 'upload' && (
-            <div className="space-y-6">
-              <div className="p-4 bg-primary-800 rounded-lg">
-                <p className="text-xs uppercase text-neutral-500 mb-2">Outfit Items ({items.length})</p>
-                <div className="flex -space-x-2 overflow-hidden">
-                  {items.slice(0, 5).map((i, idx) => (
-                    <img key={idx} src={i.item.image_url} alt="Item" className="inline-block h-10 w-10 rounded-full ring-2 ring-primary-900 bg-primary-700 object-cover" />
-                  ))}
-                  {items.length > 5 && (
-                    <div className="flex items-center justify-center h-10 w-10 rounded-full ring-2 ring-primary-900 bg-primary-700 text-xs text-white">+{items.length - 5}</div>
-                  )}
+    <Modal isOpen={true} onClose={onClose} title="Try On Full Outfit" size="md">
+      {step === 'upload' && (
+        <div className="space-y-[var(--space-6)]">
+          <Card className="p-[var(--space-4)]">
+            <p className="mb-[var(--space-2)] text-xs uppercase text-neutral-500">Outfit Items ({items.length})</p>
+            <div className="flex -space-x-2 overflow-hidden" aria-label={`${items.length} items in outfit`}>
+              {items.slice(0, 5).map((entry, index) => (
+                entry.item.image_url ? (
+                  <img
+                    key={index}
+                    src={entry.item.image_url}
+                    alt={entry.item.category.l2 || 'Outfit item'}
+                    className="inline-block h-10 w-10 rounded-full bg-primary-700 object-cover ring-2 ring-primary-900"
+                  />
+                ) : (
+                  <div
+                    key={index}
+                    className="flex h-10 w-10 items-center justify-center rounded-full bg-primary-700 text-[10px] text-white ring-2 ring-primary-900"
+                  >
+                    {(entry.item.category.l2 || 'Item').slice(0, 1)}
+                  </div>
+                )
+              ))}
+              {items.length > 5 && (
+                <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary-700 text-xs text-white ring-2 ring-primary-900">
+                  +{items.length - 5}
                 </div>
-              </div>
-
-              <ImageUploadZone 
-                onFileSelect={setUserPhotoFile} 
-                label="Upload full body photo" 
-                compact={true}
-                previewFile={userPhotoFile}
-                onClear={() => setUserPhotoFile(null)}
-              />
-
-              {error && <p className="text-error-500 text-sm text-center">{error}</p>}
-
-              <button
-                onClick={handleGenerate}
-                disabled={!userPhotoFile}
-                className="w-full flex items-center justify-center gap-2 px-6 py-4 bg-white text-primary-900 hover:bg-neutral-200 disabled:opacity-30 text-xs font-bold uppercase tracking-widest"
-              >
-                <Sparkles size={16} /> Generate Full Outfit
-              </button>
+              )}
             </div>
+          </Card>
+
+          <ImageUploadZone
+            onFileSelect={setUserPhotoFile}
+            label="Upload full body photo"
+            compact={true}
+            previewFile={userPhotoFile}
+            onClear={() => setUserPhotoFile(null)}
+          />
+
+          {error && (
+            <p className="text-center text-sm text-error-400" role="alert">
+              {error}
+            </p>
           )}
 
-          {step === 'generating' && (
-            <div className="py-12 flex flex-col items-center justify-center text-center">
-              <div className="relative w-20 h-20 mb-6">
-                <div className="absolute inset-0 border-4 border-primary-800 rounded-full" />
-                <div className="absolute inset-0 border-4 border-accent-500 border-t-transparent rounded-full animate-spin" />
-              </div>
-              <h4 className="text-lg font-bold text-white mb-2">Generating Outfit...</h4>
-              <p className="text-neutral-500 text-sm max-w-xs">We are stitching {items.length} items onto your photo.</p>
-            </div>
-          )}
-
-          {step === 'result' && resultUrl && (
-            <TryOnResult 
-              imageUrl={resultUrl}
-              processingTime={processingTime || undefined}
-              onRetry={() => { setStep('upload'); setUserPhotoFile(null) }}
-              onDownload={handleDownload}
-              onDone={onClose}
-            />
-          )}
+          <Button
+            onClick={handleGenerate}
+            disabled={!userPhotoFile}
+            fullWidth
+            leftIcon={<Sparkles size={16} aria-hidden="true" />}
+          >
+            Generate Full Outfit
+          </Button>
         </div>
-      </div>
-    </div>
+      )}
+
+      {step === 'generating' && (
+        <div className="flex flex-col items-center justify-center py-[var(--space-12)] text-center">
+          <div className="relative mb-[var(--space-6)] h-20 w-20">
+            <div className="absolute inset-0 rounded-full border-4 border-primary-800" />
+            <div className="absolute inset-0 animate-spin rounded-full border-4 border-accent-500 border-t-transparent" />
+          </div>
+          <h4 className="mb-[var(--space-2)] text-lg font-bold text-white">Generating Outfit...</h4>
+          <p className="max-w-xs text-sm text-neutral-500">
+            We are stitching {items.length} items onto your photo.
+          </p>
+        </div>
+      )}
+
+      {step === 'result' && resultUrl && (
+        <TryOnResult
+          imageUrl={resultUrl}
+          processingTime={processingTime || undefined}
+          onRetry={() => {
+            setStep('upload')
+            setUserPhotoFile(null)
+          }}
+          onDownload={handleDownload}
+          onDone={onClose}
+        />
+      )}
+    </Modal>
   )
 }

--- a/frontend/src/app/style/components/shared/ColorPickerModal.tsx
+++ b/frontend/src/app/style/components/shared/ColorPickerModal.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import { useState, useCallback, useRef, useEffect } from 'react'
-import { X } from 'lucide-react'
 import { hexToHsl, hslToHex } from '@/lib/colorUtils'
+import { Button, Modal } from '@/components/ui'
 
 interface ColorPickerModalProps {
   initialColor: string
@@ -11,47 +11,42 @@ interface ColorPickerModalProps {
 }
 
 export default function ColorPickerModal({ initialColor, onSelect, onClose }: ColorPickerModalProps) {
-  // Safe default if initialColor is invalid
   const initialHsl = hexToHsl(initialColor) || { h: 0, s: 0, l: 50 }
-  
+
   const [hue, setHue] = useState(initialHsl.h)
   const [saturation, setSaturation] = useState(initialHsl.s)
   const [lightness, setLightness] = useState(initialHsl.l)
-  
+
   const satLightRef = useRef<HTMLDivElement>(null)
   const [isDragging, setIsDragging] = useState(false)
 
   const currentHex = hslToHex(hue, saturation, lightness)
 
-  // Handle saturation/lightness picker
-  const handleSatLightChange = useCallback((e: React.MouseEvent | MouseEvent) => {
+  const handleSatLightChange = useCallback((event: React.MouseEvent | MouseEvent) => {
     if (!satLightRef.current) return
-    
+
     const rect = satLightRef.current.getBoundingClientRect()
-    const x = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width))
-    const y = Math.max(0, Math.min(1, (e.clientY - rect.top) / rect.height))
-    
+    const x = Math.max(0, Math.min(1, (event.clientX - rect.left) / rect.width))
+    const y = Math.max(0, Math.min(1, (event.clientY - rect.top) / rect.height))
+
     setSaturation(Math.round(x * 100))
     setLightness(Math.round((1 - y) * 100))
   }, [])
 
-  // Mouse event handlers for dragging
   useEffect(() => {
-    const handleMouseMove = (e: MouseEvent) => {
-      if (isDragging) {
-        handleSatLightChange(e)
-      }
+    const handleMouseMove = (event: MouseEvent) => {
+      if (isDragging) handleSatLightChange(event)
     }
-    
+
     const handleMouseUp = () => {
       setIsDragging(false)
     }
-    
+
     if (isDragging) {
       document.addEventListener('mousemove', handleMouseMove)
       document.addEventListener('mouseup', handleMouseUp)
     }
-    
+
     return () => {
       document.removeEventListener('mousemove', handleMouseMove)
       document.removeEventListener('mouseup', handleMouseUp)
@@ -59,110 +54,108 @@ export default function ColorPickerModal({ initialColor, onSelect, onClose }: Co
   }, [isDragging, handleSatLightChange])
 
   return (
-    <div className="fixed inset-0 bg-primary-900/95 backdrop-blur-sm flex items-center justify-center z-50">
-      <div className="bg-primary-900 w-full max-w-md mx-4 border border-primary-700 shadow-2xl animate-in fade-in zoom-in duration-200 rounded-xl overflow-hidden">
-        
-        {/* Header */}
-        <div className="flex items-center justify-between px-6 py-4 border-b border-primary-800">
-          <h3 className="text-lg font-bold uppercase tracking-widest text-white">
-            Pick Color
-          </h3>
-          <button
-            onClick={onClose}
-            className="text-neutral-500 hover:text-white transition-colors p-1"
-          >
-            <X size={20} />
-          </button>
+    <Modal
+      isOpen={true}
+      onClose={onClose}
+      title="Pick Color"
+      size="sm"
+      footer={
+        <div className="flex justify-end gap-[var(--space-3)]">
+          <Button variant="ghost" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button onClick={() => onSelect(currentHex)}>Select Color</Button>
+        </div>
+      }
+    >
+      <div className="space-y-[var(--space-6)]">
+        <div
+          ref={satLightRef}
+          onMouseDown={(event) => {
+            setIsDragging(true)
+            handleSatLightChange(event)
+          }}
+          onKeyDown={(event) => {
+            if (event.key === 'ArrowLeft') {
+              event.preventDefault()
+              setSaturation((value) => Math.max(0, value - 2))
+            }
+            if (event.key === 'ArrowRight') {
+              event.preventDefault()
+              setSaturation((value) => Math.min(100, value + 2))
+            }
+            if (event.key === 'ArrowUp') {
+              event.preventDefault()
+              setLightness((value) => Math.min(100, value + 2))
+            }
+            if (event.key === 'ArrowDown') {
+              event.preventDefault()
+              setLightness((value) => Math.max(0, value - 2))
+            }
+          }}
+          tabIndex={0}
+          role="application"
+          aria-label="Saturation and lightness selector"
+          className="relative h-64 w-full cursor-crosshair rounded-[var(--radius-md)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500"
+          style={{
+            background: `
+              linear-gradient(to top, #000, transparent),
+              linear-gradient(to right, #fff, hsl(${hue}, 100%, 50%))
+            `,
+          }}
+        >
+          <div
+            className="pointer-events-none absolute h-4 w-4 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-white shadow-lg"
+            style={{
+              left: `${saturation}%`,
+              top: `${100 - lightness}%`,
+              backgroundColor: currentHex,
+            }}
+          />
         </div>
 
-        {/* Picker Area */}
-        <div className="p-6 space-y-6">
-          
-          {/* Saturation/Lightness Square */}
-          <div
-            ref={satLightRef}
-            onMouseDown={(e) => {
-              setIsDragging(true)
-              handleSatLightChange(e)
-            }}
-            className="relative w-full h-64 rounded cursor-crosshair"
+        <div>
+          <label className="mb-[var(--space-2)] block text-[10px] font-bold uppercase tracking-widest text-neutral-500">
+            Hue
+          </label>
+          <input
+            type="range"
+            min={0}
+            max={360}
+            value={hue}
+            onChange={(event) => setHue(Number(event.target.value))}
+            className="h-3 w-full cursor-pointer appearance-none rounded-full"
             style={{
-              background: `
-                linear-gradient(to top, #000, transparent),
-                linear-gradient(to right, #fff, hsl(${hue}, 100%, 50%))
-              `
+              background: `linear-gradient(to right,
+                hsl(0, 100%, 50%),
+                hsl(60, 100%, 50%),
+                hsl(120, 100%, 50%),
+                hsl(180, 100%, 50%),
+                hsl(240, 100%, 50%),
+                hsl(300, 100%, 50%),
+                hsl(360, 100%, 50%)
+              )`,
             }}
-          >
-            {/* Indicator */}
-            <div
-              className="absolute w-4 h-4 border-2 border-white rounded-full -translate-x-1/2 -translate-y-1/2 pointer-events-none shadow-lg"
-              style={{
-                left: `${saturation}%`,
-                top: `${100 - lightness}%`,
-                backgroundColor: currentHex,
-              }}
-            />
-          </div>
+            aria-label="Hue slider"
+          />
+        </div>
 
-          {/* Hue Slider */}
-          <div>
-            <label className="block text-[10px] uppercase font-bold tracking-widest text-neutral-500 mb-2">
-              Hue
+        <div className="flex items-center gap-[var(--space-4)]">
+          <div
+            className="h-16 w-16 rounded-[var(--radius-md)] border border-primary-600"
+            style={{ backgroundColor: currentHex }}
+            aria-hidden="true"
+          />
+          <div className="flex-1">
+            <label className="mb-[var(--space-1)] block text-[10px] font-bold uppercase tracking-widest text-neutral-500">
+              Hex Value
             </label>
-            <input
-              type="range"
-              min={0}
-              max={360}
-              value={hue}
-              onChange={(e) => setHue(Number(e.target.value))}
-              className="w-full h-3 rounded-full appearance-none cursor-pointer"
-              style={{
-                background: `linear-gradient(to right, 
-                  hsl(0, 100%, 50%), 
-                  hsl(60, 100%, 50%), 
-                  hsl(120, 100%, 50%), 
-                  hsl(180, 100%, 50%), 
-                  hsl(240, 100%, 50%), 
-                  hsl(300, 100%, 50%), 
-                  hsl(360, 100%, 50%)
-                )`
-              }}
-            />
-          </div>
-
-          {/* Preview & Hex */}
-          <div className="flex items-center gap-4">
-            <div
-              className="w-16 h-16 rounded border border-primary-600"
-              style={{ backgroundColor: currentHex }}
-            />
-            <div className="flex-1">
-              <label className="block text-[10px] uppercase font-bold tracking-widest text-neutral-500 mb-1">
-                Hex Value
-              </label>
-              <div className="px-4 py-2 bg-primary-800 border border-primary-700 text-white font-mono text-sm tracking-wider">
-                {currentHex}
-              </div>
+            <div className="rounded-[var(--radius-md)] border border-primary-700 bg-primary-800 px-[var(--space-4)] py-[var(--space-2)] font-mono text-sm tracking-wider text-white">
+              {currentHex}
             </div>
           </div>
         </div>
-
-        {/* Footer */}
-        <div className="flex justify-end gap-3 px-6 py-4 border-t border-primary-800">
-          <button
-            onClick={onClose}
-            className="px-6 py-2.5 text-neutral-400 hover:text-white text-xs font-bold uppercase tracking-widest transition-colors"
-          >
-            Cancel
-          </button>
-          <button
-            onClick={() => onSelect(currentHex)}
-            className="px-6 py-2.5 bg-white text-primary-900 hover:bg-neutral-200 text-xs font-bold uppercase tracking-widest transition-all"
-          >
-            Select Color
-          </button>
-        </div>
       </div>
-    </div>
+    </Modal>
   )
 }

--- a/frontend/src/app/style/components/shared/ImageUploadZone.tsx
+++ b/frontend/src/app/style/components/shared/ImageUploadZone.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { useRef, useCallback, useState, useEffect } from 'react'
-import { Upload } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { Button, FileUploadInput } from '@/components/ui'
 
 interface ImageUploadZoneProps {
   onFileSelect: (file: File) => void
@@ -13,108 +13,57 @@ interface ImageUploadZoneProps {
   onClear?: () => void
 }
 
-export default function ImageUploadZone({ 
-  onFileSelect, 
-  label = "Drop your image",
-  subLabel = "or click to browse",
+export default function ImageUploadZone({
+  onFileSelect,
+  label = 'Drop your image',
+  subLabel = 'or click to browse',
   compact = false,
   disabled = false,
   previewFile = null,
-  onClear
+  onClear,
 }: ImageUploadZoneProps) {
-  const [isDragging, setIsDragging] = useState(false)
   const [previewUrl, setPreviewUrl] = useState<string | null>(null)
-  const fileInputRef = useRef<HTMLInputElement>(null)
 
-  // Create preview URL when previewFile changes
   useEffect(() => {
     if (previewFile) {
       const url = URL.createObjectURL(previewFile)
       setPreviewUrl(url)
       return () => URL.revokeObjectURL(url)
     }
+
     setPreviewUrl(null)
   }, [previewFile])
 
-  const handleFile = useCallback((file: File) => {
-    if (!file.type.startsWith('image/')) {
-      alert('Please select an image file')
-      return
-    }
-    if (file.size > 10 * 1024 * 1024) {
-      alert('File size must be less than 10MB')
-      return
-    }
-    onFileSelect(file)
-  }, [onFileSelect])
-
-  const handleDrop = useCallback((e: React.DragEvent) => {
-    e.preventDefault()
-    setIsDragging(false)
-    const file = e.dataTransfer.files[0]
-    if (file) handleFile(file)
-  }, [handleFile])
-
-  const containerClasses = compact
-    ? `h-64 rounded-lg border-2 border-dashed cursor-pointer transition-all flex flex-col items-center justify-center gap-4`
-    : `relative w-full max-w-xl h-96 rounded-xl border-2 border-dashed cursor-pointer transition-all duration-300 flex flex-col items-center justify-center gap-6`
-
-  const activeClasses = isDragging 
-    ? 'border-accent-500 bg-accent-500/10 scale-[1.02]' 
-    : 'border-primary-600 bg-primary-800/30 hover:border-primary-500 hover:bg-primary-800/50'
-
-  const disabledClasses = disabled ? 'opacity-50 cursor-not-allowed pointer-events-none' : ''
-
   return (
-    <div className="space-y-3">
+    <div className="space-y-[var(--space-3)]">
       {previewUrl ? (
-        <div className={`relative rounded-lg bg-primary-800 border border-primary-700 overflow-y-auto scrollbar-hide ${compact ? 'max-h-64' : 'max-h-96'}`}>
-        <img src={previewUrl} alt="Preview" className="w-full h-auto" />
-        </div>
-        ) : (
         <div
-      onClick={() => !disabled && fileInputRef.current?.click()}
-      onDrop={(e) => !disabled && handleDrop(e)}
-      onDragOver={(e) => { if (!disabled) { e.preventDefault(); setIsDragging(true) } }}
-      onDragLeave={(e) => { if (!disabled) { e.preventDefault(); setIsDragging(false) } }}
-      className={`${containerClasses} ${activeClasses} ${disabledClasses}`}
-    >
-      <div className={`
-        rounded-full transition-all duration-300
-        ${compact ? '' : 'p-6'}
-        ${isDragging ? 'bg-accent-500/20' : compact ? '' : 'bg-primary-800'}
-      `}>
-        <Upload 
-          size={compact ? 32 : 32} 
-          className={isDragging ? 'text-accent-500' : 'text-neutral-500'} 
-        />
-      </div>
-
-      <div className="text-center">
-        <h3 className={`
-          font-bold uppercase tracking-widest transition-colors
-          ${compact ? 'text-base' : 'text-lg mb-2'}
-          ${isDragging ? 'text-accent-500' : 'text-white'}
-        `}>
-          {isDragging ? 'Drop it here!' : label}
-        </h3>
-        <p className="text-neutral-500 text-sm">
-          {compact ? '' : 'or '}<span className={compact ? '' : "text-white underline underline-offset-4"}>{subLabel}</span>
-        </p>
-      </div>
-
-      <p className="text-neutral-600 text-xs uppercase tracking-wider">
-        PNG, JPG, WEBP • Max 10MB
-      </p>
-
-      <input
-        ref={fileInputRef}
-        type="file"
-        accept="image/*"
-        onChange={(e) => e.target.files?.[0] && handleFile(e.target.files[0])}
-        className="hidden"
-      />
+          className={`relative overflow-y-auto rounded-[var(--radius-lg)] border border-primary-700 bg-primary-800 scrollbar-hide ${
+            compact ? 'max-h-64' : 'max-h-96'
+          }`}
+        >
+          <img src={previewUrl} alt="Preview" className="h-auto w-full" />
+          {onClear && (
+            <div className="absolute right-[var(--space-3)] top-[var(--space-3)]">
+              <Button variant="secondary" size="sm" onClick={onClear}>
+                Change
+              </Button>
+            </div>
+          )}
         </div>
+      ) : (
+        <FileUploadInput
+          label={label}
+          dropLabel={compact ? label : `${label} ${subLabel}`}
+          onFileSelect={onFileSelect}
+          onClear={onClear}
+          selectedFile={previewFile}
+          disabled={disabled}
+          accept="image/png,image/jpeg,image/webp,image/heic,image/heif"
+          maxSizeMB={10}
+          className={compact ? '' : 'max-w-xl'}
+          hint="PNG, JPG, WEBP • Max 10MB"
+        />
       )}
     </div>
   )

--- a/frontend/src/app/style/components/shared/SuggestionPanel.tsx
+++ b/frontend/src/app/style/components/shared/SuggestionPanel.tsx
@@ -1,11 +1,12 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { Sparkles, Lightbulb, Package, Plus, Check } from 'lucide-react'
+import { Sparkles, Lightbulb, Package, Plus } from 'lucide-react'
 import { useAuth } from '@/components/AuthProvider'
 import { getMatchingItems } from '@/lib/api'
 import type { CategoryRecommendation, RecommendedColor, ClothingItemResponse } from '@/types'
 import { FORMALITY_LEVELS } from '@/types'
+import { Badge, RecommendationCard, type BadgeTone } from '@/components/ui'
 
 interface SuggestionPanelProps {
   recommendation: CategoryRecommendation | null
@@ -14,19 +15,18 @@ interface SuggestionPanelProps {
   onQuickAdd?: (item: ClothingItemResponse) => void
 }
 
-// Harmony type styling
-const getHarmonyStyle = (type: string) => {
+const getHarmonyTone = (type: string): BadgeTone => {
   switch (type) {
     case 'complementary':
-      return 'bg-purple-500/20 text-purple-400 border-purple-500/30'
+      return 'accent'
     case 'analogous':
-      return 'bg-blue-500/20 text-blue-400 border-blue-500/30'
+      return 'info'
     case 'triadic':
-      return 'bg-green-500/20 text-green-400 border-green-500/30'
+      return 'success'
     case 'neutral':
-      return 'bg-neutral-500/20 text-neutral-400 border-neutral-500/30'
+      return 'neutral'
     default:
-      return 'bg-neutral-500/20 text-neutral-400 border-neutral-500/30'
+      return 'neutral'
   }
 }
 
@@ -210,23 +210,14 @@ export default function SuggestionPanel({
           </label>
           <div className="space-y-2">
             {recommendation.colors.map((color, i) => (
-              <button
+              <RecommendationCard
                 key={i}
                 onClick={() => onColorClick?.(color)}
-                className="w-full group flex items-center gap-3 p-3 bg-primary-800 rounded-lg border border-primary-700 hover:border-primary-500 transition-all"
-              >
-                <div
-                  className="w-8 h-8 rounded-full border-2 border-primary-600 group-hover:scale-110 transition-transform"
-                  style={{ backgroundColor: color.hex }}
-                />
-                <div className="flex-1 text-left">
-                  <span className="text-sm text-white font-medium block">{color.name}</span>
-                  <span className="text-[10px] text-neutral-500 uppercase">{color.hex}</span>
-                </div>
-                <span className={`text-[9px] uppercase px-2 py-1 rounded border ${getHarmonyStyle(color.harmony_type)}`}>
-                  {color.harmony_type}
-                </span>
-              </button>
+                title={color.name}
+                description={color.hex}
+                swatchHex={color.hex}
+                meta={<Badge tone={getHarmonyTone(color.harmony_type)}>{color.harmony_type}</Badge>}
+              />
             ))}
           </div>
         </div>

--- a/frontend/src/components/AuthModal.tsx
+++ b/frontend/src/components/AuthModal.tsx
@@ -1,7 +1,8 @@
 'use client'
+
 import { useState } from 'react'
 import { supabase } from '@/lib/supabase'
-import { X, Loader2 } from 'lucide-react' // Added Loader icon
+import { Button, Modal, TextInput } from '@/components/ui'
 
 interface AuthModalProps {
   isOpen: boolean
@@ -9,16 +10,14 @@ interface AuthModalProps {
 }
 
 export default function AuthModal({ isOpen, onClose }: AuthModalProps) {
-  const [isLogin, setIsLogin] = useState(true) // Default to Login now (Standard UX)
+  const [isLogin, setIsLogin] = useState(true)
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  if (!isOpen) return null
-
-  const handleAuth = async (e: React.FormEvent) => {
-    e.preventDefault()
+  const handleAuth = async (event: React.FormEvent) => {
+    event.preventDefault()
     setLoading(true)
     setError(null)
 
@@ -30,96 +29,75 @@ export default function AuthModal({ isOpen, onClose }: AuthModalProps) {
         const { error } = await supabase.auth.signUp({ email, password })
         if (error) throw error
       }
+
       onClose()
-    } catch (err: any) {
-      setError(err.message)
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        setError(err.message)
+      } else {
+        setError('Authentication failed')
+      }
     } finally {
       setLoading(false)
     }
   }
 
   return (
-    // OVERLAY: Darker and blurrier for focus
-    <div className="fixed inset-0 bg-primary-900/80 backdrop-blur-sm flex items-center justify-center z-[60]">
-      
-      {/* MODAL CARD: Dark theme, thin border, shadow */}
-      <div className="bg-primary-900 p-8 w-full max-w-md relative border border-primary-700 animate-in fade-in zoom-in duration-200">
-        
-        {/* Close Button: Neutral to White hover */}
-        <button 
-          onClick={onClose} 
-          className="absolute top-6 right-6 text-neutral-500 hover:text-white transition-colors"
-        >
-          <X size={20} strokeWidth={1.5} />
-        </button>
-        
-        {/* HEADER */}
-        <div className="mb-8 text-center">
-          <h2 className="text-2xl font-bold uppercase tracking-widest text-white mb-2">
-            {isLogin ? 'Welcome Back' : 'Join US'}
-          </h2>
-        </div>
-        
-        {/* ERROR MESSAGE */}
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={isLogin ? 'Welcome Back' : 'Join Us'}
+      size="sm"
+    >
+      <div className="space-y-[var(--space-6)]">
         {error && (
-          <div className="bg-error-500/10 border border-error-500/50 text-error-500 p-3 mb-6 text-xs font-medium text-center uppercase tracking-wide">
+          <div
+            className="rounded-[var(--radius-md)] border border-error-500/40 bg-error-500/10 px-[var(--space-3)] py-[var(--space-3)] text-xs font-medium uppercase tracking-wide text-error-400"
+            role="alert"
+          >
             {error}
           </div>
         )}
 
-        {/* FORM */}
-        <form onSubmit={handleAuth} className="space-y-5">
-          
-          {/* EMAIL INPUT */}
-          <div className="space-y-1">
-            <label className="text-[10px] uppercase font-bold tracking-widest text-neutral-500 ml-1">Email</label>
-            <input 
-              type="email" 
-              className="w-full p-4 bg-primary-800 border border-primary-700 text-white focus:outline-none focus:border-accent-500 focus:bg-primary-800/80 transition-all placeholder-primary-600 text-sm"
-              placeholder="name@example.com"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              required
-            />
-          </div>
+        <form onSubmit={handleAuth} className="space-y-[var(--space-4)]">
+          <TextInput
+            type="email"
+            label="Email"
+            placeholder="name@example.com"
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            required
+            autoFocus
+          />
 
-          {/* PASSWORD INPUT */}
-          <div className="space-y-1">
-            <label className="text-[10px] uppercase font-bold tracking-widest text-neutral-500 ml-1">Password</label>
-            <input 
-              type="password" 
-              className="w-full p-4 bg-primary-800 border border-primary-700 text-white focus:outline-none focus:border-accent-500 focus:bg-primary-800/80 transition-all placeholder-primary-600 text-sm"
-              placeholder="••••••••"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              required
-            />
-          </div>
+          <TextInput
+            type="password"
+            label="Password"
+            placeholder="••••••••"
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+            required
+          />
 
-          {/* SUBMIT BUTTON: High Contrast White */}
-          <button 
-            type="submit" 
-            disabled={loading}
-            className="w-full bg-white text-black py-4 mt-4 hover:bg-neutral-200 disabled:opacity-50 text-xs font-bold uppercase tracking-widest transition-all flex items-center justify-center gap-2"
-          >
-            {loading && <Loader2 size={14} className="animate-spin"/>}
+          <Button type="submit" fullWidth loading={loading}>
             {isLogin ? 'Log In' : 'Create Account'}
-          </button>
+          </Button>
         </form>
 
-        {/* FOOTER SWITCH */}
-        <div className="mt-8 pt-6 border-t border-primary-800 text-center">
-          <p className="text-neutral-500 text-xs uppercase tracking-wide">
-            {isLogin ? "Don't have an account?" : "Already have an account?"}
+        <div className="border-t border-primary-800 pt-[var(--space-4)] text-center">
+          <p className="text-xs uppercase tracking-wide text-neutral-500">
+            {isLogin ? "Don't have an account?" : 'Already have an account?'}
           </p>
-          <button 
-            onClick={() => setIsLogin(!isLogin)} 
-            className="mt-2 text-white text-xs font-bold uppercase tracking-widest hover:text-accent-500 hover:underline underline-offset-4 transition-all"
+          <Button
+            variant="ghost"
+            size="sm"
+            className="mt-[var(--space-2)]"
+            onClick={() => setIsLogin((value) => !value)}
           >
             {isLogin ? 'Sign Up Here' : 'Log In Here'}
-          </button>
+          </Button>
         </div>
       </div>
-    </div>
+    </Modal>
   )
 }

--- a/frontend/src/components/ui/Badge.tsx
+++ b/frontend/src/components/ui/Badge.tsx
@@ -1,0 +1,106 @@
+import type { HTMLAttributes } from 'react'
+import { FORMALITY_LEVELS } from '@/types'
+import { cn } from '@/lib/cn'
+
+export type BadgeTone = 'neutral' | 'accent' | 'success' | 'warning' | 'danger' | 'info'
+export type BadgeSize = 'sm' | 'md'
+
+type StatusType = 'owned' | 'wishlist' | 'success' | 'warning' | 'error' | 'info'
+
+const toneClasses: Record<BadgeTone, string> = {
+  neutral: 'bg-primary-800 text-neutral-300 border-primary-700',
+  accent: 'bg-accent-500/15 text-accent-400 border-accent-500/40',
+  success: 'bg-success-500/15 text-success-400 border-success-500/40',
+  warning: 'bg-warning-500/15 text-warning-400 border-warning-500/40',
+  danger: 'bg-error-500/15 text-error-400 border-error-500/40',
+  info: 'bg-primary-700/80 text-neutral-100 border-primary-600',
+}
+
+const sizeClasses: Record<BadgeSize, string> = {
+  sm: 'px-[var(--space-2)] py-[2px] text-[9px]',
+  md: 'px-[var(--space-2)] py-[var(--space-1)] text-[10px]',
+}
+
+const categoryToneMap: Record<string, BadgeTone> = {
+  tops: 'info',
+  bottoms: 'neutral',
+  shoes: 'accent',
+  outerwear: 'warning',
+  accessories: 'success',
+}
+
+const statusToneMap: Record<StatusType, BadgeTone> = {
+  owned: 'success',
+  wishlist: 'accent',
+  success: 'success',
+  warning: 'warning',
+  error: 'danger',
+  info: 'info',
+}
+
+const statusLabelMap: Record<StatusType, string> = {
+  owned: 'Owned',
+  wishlist: 'Wishlist',
+  success: 'Success',
+  warning: 'Warning',
+  error: 'Error',
+  info: 'Info',
+}
+
+export interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
+  tone?: BadgeTone
+  size?: BadgeSize
+}
+
+export function Badge({ tone = 'neutral', size = 'md', className, children, ...props }: BadgeProps) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center rounded-[var(--radius-sm)] border font-bold uppercase tracking-wider',
+        toneClasses[tone],
+        sizeClasses[size],
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </span>
+  )
+}
+
+interface StatusBadgeProps extends Omit<BadgeProps, 'children' | 'tone'> {
+  status: StatusType
+  label?: string
+}
+
+export function StatusBadge({ status, label, ...props }: StatusBadgeProps) {
+  return (
+    <Badge tone={statusToneMap[status]} {...props}>
+      {label ?? statusLabelMap[status]}
+    </Badge>
+  )
+}
+
+interface CategoryBadgeProps extends Omit<BadgeProps, 'children' | 'tone'> {
+  category: string
+}
+
+export function CategoryBadge({ category, ...props }: CategoryBadgeProps) {
+  const tone = categoryToneMap[category.toLowerCase()] ?? 'neutral'
+  return <Badge tone={tone} {...props}>{category}</Badge>
+}
+
+interface FormalityBadgeProps extends Omit<BadgeProps, 'children' | 'tone'> {
+  level: number
+  tone?: BadgeTone
+}
+
+export function FormalityBadge({ level, tone = 'info', ...props }: FormalityBadgeProps) {
+  return (
+    <Badge tone={tone} {...props}>
+      {FORMALITY_LEVELS[level] ?? `Level ${level}`}
+    </Badge>
+  )
+}
+
+export default Badge

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -1,0 +1,82 @@
+'use client'
+
+import { forwardRef } from 'react'
+import type { ButtonHTMLAttributes, ReactNode } from 'react'
+import { cn } from '@/lib/cn'
+
+type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger'
+type ButtonSize = 'sm' | 'md' | 'lg'
+
+const variantClasses: Record<ButtonVariant, string> = {
+  primary: 'bg-white text-primary-900 border-white hover:bg-neutral-200 focus-visible:ring-white',
+  secondary: 'bg-primary-800 text-white border-primary-600 hover:bg-primary-700 focus-visible:ring-accent-500',
+  ghost: 'bg-transparent text-neutral-300 border-transparent hover:bg-primary-800 hover:text-white focus-visible:ring-accent-500',
+  danger: 'bg-error-500 text-white border-error-500 hover:bg-error-600 focus-visible:ring-error-400',
+}
+
+const sizeClasses: Record<ButtonSize, string> = {
+  sm: 'h-[var(--size-control-sm)] px-[var(--space-3)] text-[11px]',
+  md: 'h-[var(--size-control-md)] px-[var(--space-4)] text-xs',
+  lg: 'h-[var(--size-control-lg)] px-[var(--space-5)] text-sm',
+}
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant
+  size?: ButtonSize
+  loading?: boolean
+  fullWidth?: boolean
+  leftIcon?: ReactNode
+  rightIcon?: ReactNode
+}
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
+  {
+    variant = 'primary',
+    size = 'md',
+    loading = false,
+    disabled,
+    fullWidth = false,
+    leftIcon,
+    rightIcon,
+    className,
+    children,
+    type,
+    ...props
+  },
+  ref
+) {
+  const isDisabled = disabled || loading
+
+  return (
+    <button
+      ref={ref}
+      type={type ?? 'button'}
+      className={cn(
+        'inline-flex items-center justify-center gap-[var(--space-2)] rounded-[var(--radius-md)] border font-bold uppercase tracking-widest',
+        'transition-[background-color,border-color,color,box-shadow,transform] duration-200',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-primary-900',
+        'disabled:opacity-50 disabled:pointer-events-none',
+        sizeClasses[size],
+        variantClasses[variant],
+        fullWidth && 'w-full',
+        className
+      )}
+      disabled={isDisabled}
+      aria-busy={loading || undefined}
+      {...props}
+    >
+      {loading ? (
+        <span
+          className="h-[var(--size-icon-sm)] w-[var(--size-icon-sm)] animate-spin rounded-full border-2 border-current border-t-transparent"
+          aria-hidden="true"
+        />
+      ) : (
+        leftIcon
+      )}
+      <span>{children}</span>
+      {!loading && rightIcon}
+    </button>
+  )
+})
+
+export default Button

--- a/frontend/src/components/ui/Card.tsx
+++ b/frontend/src/components/ui/Card.tsx
@@ -1,0 +1,230 @@
+import type { HTMLAttributes, ReactNode } from 'react'
+import { Shirt, Package } from 'lucide-react'
+import { cn } from '@/lib/cn'
+
+interface CardProps extends HTMLAttributes<HTMLDivElement> {
+  interactive?: boolean
+}
+
+export function Card({ className, interactive = false, ...props }: CardProps) {
+  return (
+    <div
+      className={cn(
+        'overflow-hidden rounded-[var(--radius-lg)] border border-primary-700 bg-primary-800',
+        interactive && 'transition-all hover:border-primary-600',
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export function CardHeader({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('border-b border-primary-700 p-[var(--space-4)]', className)} {...props} />
+}
+
+export function CardBody({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('p-[var(--space-4)]', className)} {...props} />
+}
+
+export function CardFooter({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('border-t border-primary-700 p-[var(--space-4)]', className)} {...props} />
+}
+
+interface ItemCardProps {
+  title: string
+  subtitle?: string
+  imageUrl?: string | null
+  imageAlt: string
+  colorHex?: string
+  badge?: ReactNode
+  onClick?: () => void
+  className?: string
+  fallbackIcon?: ReactNode
+}
+
+export function ItemCard({
+  title,
+  subtitle,
+  imageUrl,
+  imageAlt,
+  colorHex,
+  badge,
+  onClick,
+  className,
+  fallbackIcon,
+}: ItemCardProps) {
+  const content = (
+    <>
+      <div className="relative aspect-[3/4] bg-primary-900">
+        {imageUrl ? (
+          <img src={imageUrl} alt={imageAlt} className="h-full w-full object-contain p-[var(--space-3)]" />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center text-neutral-600">
+            {fallbackIcon ?? <Shirt size={30} strokeWidth={1.5} aria-hidden="true" />}
+          </div>
+        )}
+
+        {colorHex && (
+          <div
+            className="absolute bottom-[var(--space-2)] left-[var(--space-2)] h-5 w-5 rounded-full border-2 border-primary-900"
+            style={{ backgroundColor: colorHex }}
+            aria-hidden="true"
+          />
+        )}
+
+        {badge && <div className="absolute right-[var(--space-2)] top-[var(--space-2)]">{badge}</div>}
+      </div>
+
+      <div className="border-t border-primary-700 p-[var(--space-3)] text-left">
+        <p className="truncate text-xs font-medium text-white">{title}</p>
+        {subtitle && <p className="mt-[2px] truncate text-[10px] uppercase text-neutral-500">{subtitle}</p>}
+      </div>
+    </>
+  )
+
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        className={cn(
+          'w-full overflow-hidden rounded-[var(--radius-lg)] border border-primary-700 bg-primary-800 text-left',
+          'transition-all hover:scale-[1.02] hover:border-primary-600',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500 focus-visible:ring-offset-2 focus-visible:ring-offset-primary-900',
+          className
+        )}
+        aria-label={`Open item details for ${title}`}
+      >
+        {content}
+      </button>
+    )
+  }
+
+  return <Card className={className}>{content}</Card>
+}
+
+interface OutfitCardProps {
+  name: string
+  createdAt?: string
+  thumbnailUrl?: string | null
+  itemCount: number
+  onClick?: () => void
+  className?: string
+}
+
+export function OutfitCard({
+  name,
+  createdAt,
+  thumbnailUrl,
+  itemCount,
+  onClick,
+  className,
+}: OutfitCardProps) {
+  const content = (
+    <>
+      <div className="relative aspect-[3/4] bg-primary-900">
+        {thumbnailUrl ? (
+          <img src={thumbnailUrl} alt={`${name} preview`} className="h-full w-full object-cover" />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center text-neutral-600">
+            <Package size={30} strokeWidth={1.5} aria-hidden="true" />
+          </div>
+        )}
+
+        <div className="absolute right-[var(--space-2)] top-[var(--space-2)] rounded-[var(--radius-sm)] border border-primary-700 bg-primary-900/90 px-[var(--space-2)] py-[2px] text-[10px] font-bold uppercase tracking-wider text-white">
+          {itemCount} {itemCount === 1 ? 'item' : 'items'}
+        </div>
+      </div>
+
+      <div className="border-t border-primary-700 p-[var(--space-3)] text-left">
+        <p className="truncate text-xs font-medium text-white">{name}</p>
+        {createdAt && <p className="mt-[2px] text-[10px] uppercase text-neutral-500">{createdAt}</p>}
+      </div>
+    </>
+  )
+
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        className={cn(
+          'w-full overflow-hidden rounded-[var(--radius-lg)] border border-primary-700 bg-primary-800 text-left',
+          'transition-all hover:scale-[1.02] hover:border-primary-600',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500 focus-visible:ring-offset-2 focus-visible:ring-offset-primary-900',
+          className
+        )}
+        aria-label={`Open outfit details for ${name}`}
+      >
+        {content}
+      </button>
+    )
+  }
+
+  return <Card className={className}>{content}</Card>
+}
+
+interface RecommendationCardProps {
+  title: string
+  description?: string
+  swatchHex?: string
+  meta?: ReactNode
+  action?: ReactNode
+  onClick?: () => void
+  className?: string
+}
+
+export function RecommendationCard({
+  title,
+  description,
+  swatchHex,
+  meta,
+  action,
+  onClick,
+  className,
+}: RecommendationCardProps) {
+  const content = (
+    <div className="flex items-center gap-[var(--space-3)] p-[var(--space-3)] text-left">
+      {swatchHex ? (
+        <div
+          className="h-8 w-8 rounded-full border-2 border-primary-600"
+          style={{ backgroundColor: swatchHex }}
+          aria-hidden="true"
+        />
+      ) : (
+        <div className="h-8 w-8 rounded-full border border-primary-700 bg-primary-700/70" aria-hidden="true" />
+      )}
+
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-medium text-white">{title}</p>
+        {description && <p className="truncate text-[10px] uppercase text-neutral-500">{description}</p>}
+      </div>
+
+      {meta}
+      {action}
+    </div>
+  )
+
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        className={cn(
+          'w-full overflow-hidden rounded-[var(--radius-lg)] border border-primary-700 bg-primary-800',
+          'transition-all hover:border-primary-500',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500 focus-visible:ring-offset-2 focus-visible:ring-offset-primary-900',
+          className
+        )}
+        aria-label={title}
+      >
+        {content}
+      </button>
+    )
+  }
+
+  return <Card className={className}>{content}</Card>
+}
+
+export default Card

--- a/frontend/src/components/ui/Input.tsx
+++ b/frontend/src/components/ui/Input.tsx
@@ -1,0 +1,319 @@
+'use client'
+
+import { useId, useRef, useState } from 'react'
+import type { InputHTMLAttributes, ReactNode, SelectHTMLAttributes } from 'react'
+import { ChevronDown, Upload, X } from 'lucide-react'
+import { cn } from '@/lib/cn'
+
+interface FieldProps {
+  id?: string
+  label: string
+  hint?: string
+  error?: string
+  required?: boolean
+  className?: string
+}
+
+function getDescribedBy(id: string, hint?: string, error?: string) {
+  const ids = []
+  if (hint) ids.push(`${id}-hint`)
+  if (error) ids.push(`${id}-error`)
+  return ids.length > 0 ? ids.join(' ') : undefined
+}
+
+function FieldMeta({ id, hint, error }: { id: string; hint?: string; error?: string }) {
+  return (
+    <>
+      {hint && (
+        <p id={`${id}-hint`} className="mt-[var(--space-1)] text-[11px] text-neutral-500">
+          {hint}
+        </p>
+      )}
+      {error && (
+        <p id={`${id}-error`} className="mt-[var(--space-1)] text-[11px] text-error-400" role="alert">
+          {error}
+        </p>
+      )}
+    </>
+  )
+}
+
+export interface TextInputProps
+  extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size'>,
+    FieldProps {
+  leftIcon?: ReactNode
+}
+
+export function TextInput({
+  id,
+  label,
+  hint,
+  error,
+  required,
+  className,
+  leftIcon,
+  type = 'text',
+  ...props
+}: TextInputProps) {
+  const generatedId = useId()
+  const fieldId = id ?? generatedId
+  const describedBy = getDescribedBy(fieldId, hint, error)
+
+  return (
+    <div className={cn('space-y-[var(--space-1)]', className)}>
+      <label htmlFor={fieldId} className="block text-[10px] font-bold uppercase tracking-widest text-neutral-500">
+        {label}
+        {required && <span className="ml-[2px] text-accent-500">*</span>}
+      </label>
+
+      <div className="relative">
+        {leftIcon && <span className="pointer-events-none absolute left-[var(--space-3)] top-1/2 -translate-y-1/2 text-neutral-600">{leftIcon}</span>}
+        <input
+          id={fieldId}
+          type={type}
+          required={required}
+          aria-invalid={Boolean(error)}
+          aria-describedby={describedBy}
+          className={cn(
+            'h-[var(--size-control-md)] w-full rounded-[var(--radius-md)] border border-primary-700 bg-primary-800 text-sm text-white',
+            'placeholder-neutral-600 transition-colors focus:border-accent-500 focus:outline-none',
+            'disabled:cursor-not-allowed disabled:opacity-60',
+            leftIcon ? 'pl-[calc(var(--space-3)*2+var(--size-icon-sm))] pr-[var(--space-3)]' : 'px-[var(--space-3)]'
+          )}
+          {...props}
+        />
+      </div>
+
+      <FieldMeta id={fieldId} hint={hint} error={error} />
+    </div>
+  )
+}
+
+interface SelectOption {
+  value: string
+  label: string
+  disabled?: boolean
+}
+
+export interface SelectInputProps extends SelectHTMLAttributes<HTMLSelectElement>, FieldProps {
+  options: SelectOption[]
+  placeholder?: string
+}
+
+export function SelectInput({
+  id,
+  label,
+  hint,
+  error,
+  required,
+  className,
+  options,
+  placeholder,
+  ...props
+}: SelectInputProps) {
+  const generatedId = useId()
+  const fieldId = id ?? generatedId
+  const describedBy = getDescribedBy(fieldId, hint, error)
+
+  return (
+    <div className={cn('space-y-[var(--space-1)]', className)}>
+      <label htmlFor={fieldId} className="block text-[10px] font-bold uppercase tracking-widest text-neutral-500">
+        {label}
+        {required && <span className="ml-[2px] text-accent-500">*</span>}
+      </label>
+
+      <div className="relative">
+        <select
+          id={fieldId}
+          required={required}
+          aria-invalid={Boolean(error)}
+          aria-describedby={describedBy}
+          className={cn(
+            'h-[var(--size-control-md)] w-full appearance-none rounded-[var(--radius-md)] border border-primary-700 bg-primary-800 px-[var(--space-3)] pr-[calc(var(--space-3)*2+var(--size-icon-md))] text-sm text-white',
+            'transition-colors focus:border-accent-500 focus:outline-none',
+            'disabled:cursor-not-allowed disabled:opacity-60'
+          )}
+          {...props}
+        >
+          {placeholder && (
+            <option value="" disabled>
+              {placeholder}
+            </option>
+          )}
+          {options.map((option) => (
+            <option key={option.value} value={option.value} disabled={option.disabled}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+
+        <ChevronDown
+          className="pointer-events-none absolute right-[var(--space-3)] top-1/2 -translate-y-1/2 text-neutral-500"
+          size={16}
+          aria-hidden="true"
+        />
+      </div>
+
+      <FieldMeta id={fieldId} hint={hint} error={error} />
+    </div>
+  )
+}
+
+function matchesAccept(file: File, accept?: string) {
+  if (!accept) return true
+
+  const accepted = accept
+    .split(',')
+    .map((entry) => entry.trim().toLowerCase())
+    .filter(Boolean)
+
+  if (accepted.length === 0) return true
+
+  const fileType = file.type.toLowerCase()
+  const fileName = file.name.toLowerCase()
+
+  return accepted.some((pattern) => {
+    if (pattern.startsWith('.')) {
+      return fileName.endsWith(pattern)
+    }
+
+    if (pattern.endsWith('/*')) {
+      return fileType.startsWith(pattern.replace('*', ''))
+    }
+
+    return fileType === pattern
+  })
+}
+
+export interface FileUploadInputProps
+  extends Omit<InputHTMLAttributes<HTMLInputElement>, 'type' | 'onChange' | 'value' | 'size'>,
+    FieldProps {
+  onFileSelect: (file: File) => void
+  onClear?: () => void
+  selectedFile?: File | null
+  maxSizeMB?: number
+  dropLabel?: string
+}
+
+export function FileUploadInput({
+  id,
+  label,
+  hint,
+  error,
+  required,
+  className,
+  onFileSelect,
+  onClear,
+  selectedFile,
+  maxSizeMB = 10,
+  dropLabel = 'Drop file here or click to browse',
+  accept,
+  disabled,
+  ...props
+}: FileUploadInputProps) {
+  const generatedId = useId()
+  const fieldId = id ?? generatedId
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [isDragging, setIsDragging] = useState(false)
+  const [validationError, setValidationError] = useState<string | null>(null)
+
+  const resolvedError = error ?? validationError ?? undefined
+  const describedBy = getDescribedBy(fieldId, hint, resolvedError)
+
+  const validateAndSelect = (file: File) => {
+    setValidationError(null)
+
+    if (!matchesAccept(file, accept)) {
+      setValidationError('Selected file type is not allowed.')
+      return
+    }
+
+    if (file.size > maxSizeMB * 1024 * 1024) {
+      setValidationError(`File must be smaller than ${maxSizeMB}MB.`)
+      return
+    }
+
+    onFileSelect(file)
+  }
+
+  return (
+    <div className={cn('space-y-[var(--space-1)]', className)}>
+      <label htmlFor={fieldId} className="block text-[10px] font-bold uppercase tracking-widest text-neutral-500">
+        {label}
+        {required && <span className="ml-[2px] text-accent-500">*</span>}
+      </label>
+
+      <button
+        type="button"
+        onClick={() => inputRef.current?.click()}
+        disabled={disabled}
+        onDragOver={(event) => {
+          event.preventDefault()
+          if (!disabled) setIsDragging(true)
+        }}
+        onDragLeave={(event) => {
+          event.preventDefault()
+          setIsDragging(false)
+        }}
+        onDrop={(event) => {
+          event.preventDefault()
+          setIsDragging(false)
+          if (disabled) return
+          const file = event.dataTransfer.files?.[0]
+          if (file) validateAndSelect(file)
+        }}
+        className={cn(
+          'flex min-h-[120px] w-full flex-col items-center justify-center gap-[var(--space-2)] rounded-[var(--radius-lg)] border-2 border-dashed px-[var(--space-4)] py-[var(--space-5)] text-center transition-all',
+          isDragging
+            ? 'border-accent-500 bg-accent-500/10'
+            : 'border-primary-600 bg-primary-800/30 hover:border-primary-500 hover:bg-primary-800/50',
+          disabled && 'cursor-not-allowed opacity-50'
+        )}
+        aria-describedby={describedBy}
+        aria-invalid={Boolean(resolvedError)}
+      >
+        <Upload size={24} className={cn('text-neutral-500', isDragging && 'text-accent-500')} aria-hidden="true" />
+        <span className="text-sm text-white">{dropLabel}</span>
+        <span className="text-[11px] uppercase tracking-wide text-neutral-500">
+          {accept ? accept : 'Any file type'} • Max {maxSizeMB}MB
+        </span>
+      </button>
+
+      <input
+        ref={inputRef}
+        id={fieldId}
+        type="file"
+        accept={accept}
+        required={required}
+        className="hidden"
+        onChange={(event) => {
+          const file = event.target.files?.[0]
+          if (file) validateAndSelect(file)
+          event.currentTarget.value = ''
+        }}
+        disabled={disabled}
+        {...props}
+      />
+
+      {selectedFile && (
+        <div className="flex items-center justify-between rounded-[var(--radius-md)] border border-primary-700 bg-primary-800 px-[var(--space-3)] py-[var(--space-2)]">
+          <p className="truncate text-sm text-white">{selectedFile.name}</p>
+          {onClear && (
+            <button
+              type="button"
+              onClick={onClear}
+              className="rounded-[var(--radius-sm)] p-[var(--space-1)] text-neutral-500 transition-colors hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500"
+              aria-label="Remove selected file"
+            >
+              <X size={14} aria-hidden="true" />
+            </button>
+          )}
+        </div>
+      )}
+
+      <FieldMeta id={fieldId} hint={hint} error={resolvedError} />
+    </div>
+  )
+}
+
+export default TextInput

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -1,0 +1,270 @@
+'use client'
+
+import { useEffect, useId, useRef, useState } from 'react'
+import type { KeyboardEvent, ReactNode, RefObject } from 'react'
+import { AlertTriangle, X } from 'lucide-react'
+import { cn } from '@/lib/cn'
+import { Button } from './Button'
+
+const FOCUSABLE_SELECTORS = [
+  'a[href]',
+  'button:not([disabled])',
+  'textarea:not([disabled])',
+  'input:not([disabled]):not([type="hidden"])',
+  'select:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',')
+
+type ModalSize = 'sm' | 'md' | 'lg' | 'xl'
+
+const sizeClasses: Record<ModalSize, string> = {
+  sm: 'max-w-md',
+  md: 'max-w-lg',
+  lg: 'max-w-2xl',
+  xl: 'max-w-4xl',
+}
+
+export interface ModalProps {
+  isOpen: boolean
+  onClose: () => void
+  title?: ReactNode
+  description?: ReactNode
+  children: ReactNode
+  footer?: ReactNode
+  size?: ModalSize
+  closeOnBackdrop?: boolean
+  closeOnEsc?: boolean
+  showCloseButton?: boolean
+  initialFocusRef?: RefObject<HTMLElement | null>
+  className?: string
+  panelClassName?: string
+}
+
+export function Modal({
+  isOpen,
+  onClose,
+  title,
+  description,
+  children,
+  footer,
+  size = 'md',
+  closeOnBackdrop = true,
+  closeOnEsc = true,
+  showCloseButton = true,
+  initialFocusRef,
+  className,
+  panelClassName,
+}: ModalProps) {
+  const panelRef = useRef<HTMLDivElement>(null)
+  const lastFocusedRef = useRef<HTMLElement | null>(null)
+
+  const generatedTitleId = useId()
+  const generatedDescriptionId = useId()
+  const titleId = title ? generatedTitleId : undefined
+  const descriptionId = description ? generatedDescriptionId : undefined
+
+  useEffect(() => {
+    if (!isOpen) return
+
+    lastFocusedRef.current = document.activeElement as HTMLElement | null
+    const previousOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+
+    const timer = window.setTimeout(() => {
+      if (initialFocusRef?.current) {
+        initialFocusRef.current.focus()
+        return
+      }
+
+      const focusable = panelRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS)
+      if (focusable && focusable.length > 0) {
+        focusable[0].focus()
+        return
+      }
+
+      panelRef.current?.focus()
+    }, 0)
+
+    return () => {
+      window.clearTimeout(timer)
+      document.body.style.overflow = previousOverflow
+      lastFocusedRef.current?.focus()
+    }
+  }, [initialFocusRef, isOpen])
+
+  if (!isOpen) return null
+
+  const trapFocus = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Escape' && closeOnEsc) {
+      event.preventDefault()
+      onClose()
+      return
+    }
+
+    if (event.key !== 'Tab') return
+
+    const focusable = panelRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS)
+    if (!focusable || focusable.length === 0) {
+      event.preventDefault()
+      panelRef.current?.focus()
+      return
+    }
+
+    const first = focusable[0]
+    const last = focusable[focusable.length - 1]
+    const active = document.activeElement
+
+    if (event.shiftKey && active === first) {
+      event.preventDefault()
+      last.focus()
+    } else if (!event.shiftKey && active === last) {
+      event.preventDefault()
+      first.focus()
+    }
+  }
+
+  return (
+    <div className={cn('fixed inset-0 z-[70] flex items-center justify-center p-[var(--space-4)]', className)}>
+      <div
+        className="absolute inset-0 bg-black/80 backdrop-blur-sm"
+        onClick={closeOnBackdrop ? onClose : undefined}
+        aria-hidden="true"
+      />
+
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
+        tabIndex={-1}
+        onKeyDown={trapFocus}
+        className={cn(
+          'relative z-10 flex max-h-[90vh] w-full flex-col overflow-hidden rounded-[var(--radius-xl)] border border-primary-700 bg-primary-900 shadow-2xl',
+          sizeClasses[size],
+          panelClassName
+        )}
+      >
+        {(title || showCloseButton) && (
+          <div className="flex items-center justify-between border-b border-primary-800 px-[var(--space-6)] py-[var(--space-4)]">
+            <div>
+              {title && (
+                <h2 id={titleId} className="text-lg font-bold uppercase tracking-widest text-white">
+                  {title}
+                </h2>
+              )}
+              {description && (
+                <p id={descriptionId} className="mt-[var(--space-1)] text-sm text-neutral-500">
+                  {description}
+                </p>
+              )}
+            </div>
+
+            {showCloseButton && (
+              <button
+                type="button"
+                onClick={onClose}
+                className="rounded-[var(--radius-sm)] p-[var(--space-1)] text-neutral-500 transition-colors hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500"
+                aria-label="Close dialog"
+              >
+                <X size={20} aria-hidden="true" />
+              </button>
+            )}
+          </div>
+        )}
+
+        <div className="overflow-y-auto p-[var(--space-6)] scrollbar-hide">{children}</div>
+
+        {footer && <div className="border-t border-primary-800 px-[var(--space-6)] py-[var(--space-4)]">{footer}</div>}
+      </div>
+    </div>
+  )
+}
+
+interface ConfirmationModalProps {
+  isOpen: boolean
+  onClose: () => void
+  onConfirm: () => void | Promise<void>
+  title: string
+  description: string
+  confirmLabel?: string
+  cancelLabel?: string
+  tone?: 'primary' | 'danger'
+  isConfirming?: boolean
+}
+
+function isPromiseLike(value: unknown): value is Promise<unknown> {
+  return typeof value === 'object' && value !== null && 'then' in value
+}
+
+export function ConfirmationModal({
+  isOpen,
+  onClose,
+  onConfirm,
+  title,
+  description,
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+  tone = 'danger',
+  isConfirming,
+}: ConfirmationModalProps) {
+  const [internalPending, setInternalPending] = useState(false)
+
+  useEffect(() => {
+    if (!isOpen) {
+      setInternalPending(false)
+    }
+  }, [isOpen])
+
+  const pending = isConfirming ?? internalPending
+
+  const handleConfirm = async () => {
+    try {
+      const maybePromise = onConfirm()
+      if (isPromiseLike(maybePromise)) {
+        setInternalPending(true)
+        await maybePromise
+      }
+    } finally {
+      setInternalPending(false)
+    }
+  }
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={title}
+      size="sm"
+      footer={
+        <div className="flex gap-[var(--space-3)]">
+          <Button
+            variant="secondary"
+            className="flex-1"
+            onClick={onClose}
+            disabled={pending}
+          >
+            {cancelLabel}
+          </Button>
+          <Button
+            variant={tone === 'danger' ? 'danger' : 'primary'}
+            className="flex-1"
+            onClick={handleConfirm}
+            loading={pending}
+          >
+            {confirmLabel}
+          </Button>
+        </div>
+      }
+    >
+      <div className="flex items-start gap-[var(--space-3)]">
+        {tone === 'danger' && (
+          <AlertTriangle size={18} className="mt-[2px] shrink-0 text-error-400" aria-hidden="true" />
+        )}
+        <p className="text-sm leading-relaxed text-neutral-300">{description}</p>
+      </div>
+    </Modal>
+  )
+}
+
+export default Modal

--- a/frontend/src/components/ui/README.md
+++ b/frontend/src/components/ui/README.md
@@ -1,0 +1,102 @@
+# Shared UI Component Library
+
+Location: `src/components/ui`
+
+## Exports
+
+```ts
+import {
+  Button,
+  Card,
+  ItemCard,
+  OutfitCard,
+  RecommendationCard,
+  Modal,
+  ConfirmationModal,
+  TextInput,
+  SelectInput,
+  FileUploadInput,
+  Badge,
+  StatusBadge,
+  CategoryBadge,
+  FormalityBadge,
+  Skeleton,
+  CardSkeleton,
+  TextSkeleton,
+} from '@/components/ui'
+```
+
+## Design Tokens
+
+Global spacing/sizing tokens are defined in `src/app/global.css`:
+- Spacing: `--space-1` to `--space-12`
+- Controls: `--size-control-sm|md|lg`
+- Icons: `--size-icon-sm|md|lg`
+- Radius: `--radius-sm|md|lg|xl`
+
+These tokens are used by all shared UI components via `var(...)`.
+
+## Components
+
+### Button
+Variants:
+- `primary`
+- `secondary`
+- `ghost`
+- `danger`
+
+Sizes:
+- `sm`
+- `md`
+- `lg`
+
+Supports:
+- `loading`
+- `leftIcon` and `rightIcon`
+- `fullWidth`
+
+### Card
+Base:
+- `Card`
+- `CardHeader`
+- `CardBody`
+- `CardFooter`
+
+Specialized:
+- `ItemCard`
+- `OutfitCard`
+- `RecommendationCard`
+
+### Modal
+- `Modal`: base accessible dialog
+- `ConfirmationModal`: reusable destructive/confirm dialog
+
+Features:
+- Escape to close
+- Backdrop close support
+- Focus trapping
+- Focus restore on close
+- `aria-modal`, dialog labelling
+
+### Input
+- `TextInput`
+- `SelectInput`
+- `FileUploadInput`
+
+Features:
+- Label + required marker
+- Hint and error wiring via `aria-describedby`
+- Invalid state via `aria-invalid`
+- File size/type validation in `FileUploadInput`
+
+### Badge
+- `Badge`
+- `StatusBadge`
+- `CategoryBadge`
+- `FormalityBadge`
+
+### Skeleton
+- `Skeleton`
+- `CardSkeleton`
+- `TextSkeleton`
+

--- a/frontend/src/components/ui/Skeleton.tsx
+++ b/frontend/src/components/ui/Skeleton.tsx
@@ -1,0 +1,57 @@
+import type { HTMLAttributes } from 'react'
+import { cn } from '@/lib/cn'
+
+export interface SkeletonProps extends HTMLAttributes<HTMLDivElement> {}
+
+export function Skeleton({ className, ...props }: SkeletonProps) {
+  return (
+    <div
+      className={cn('animate-pulse rounded-[var(--radius-md)] bg-primary-700/80', className)}
+      aria-hidden="true"
+      {...props}
+    />
+  )
+}
+
+interface CardSkeletonProps {
+  count?: number
+}
+
+export function CardSkeleton({ count = 1 }: CardSkeletonProps) {
+  return (
+    <>
+      {Array.from({ length: count }).map((_, index) => (
+        <div
+          key={index}
+          className="overflow-hidden rounded-[var(--radius-lg)] border border-primary-700 bg-primary-800"
+          aria-hidden="true"
+        >
+          <Skeleton className="aspect-[3/4] w-full rounded-none" />
+          <div className="space-y-[var(--space-2)] p-[var(--space-3)]">
+            <Skeleton className="h-3 w-3/4" />
+            <Skeleton className="h-2.5 w-1/2" />
+          </div>
+        </div>
+      ))}
+    </>
+  )
+}
+
+interface TextSkeletonProps {
+  lines?: number
+}
+
+export function TextSkeleton({ lines = 3 }: TextSkeletonProps) {
+  return (
+    <div className="space-y-[var(--space-2)]" aria-hidden="true">
+      {Array.from({ length: lines }).map((_, index) => (
+        <Skeleton
+          key={index}
+          className={cn('h-3', index === lines - 1 ? 'w-2/3' : 'w-full')}
+        />
+      ))}
+    </div>
+  )
+}
+
+export default Skeleton

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -1,0 +1,24 @@
+export { Button } from './Button'
+export type { ButtonProps } from './Button'
+
+export { Badge, StatusBadge, CategoryBadge, FormalityBadge } from './Badge'
+export type { BadgeProps, BadgeTone, BadgeSize } from './Badge'
+
+export {
+  Card,
+  CardHeader,
+  CardBody,
+  CardFooter,
+  ItemCard,
+  OutfitCard,
+  RecommendationCard,
+} from './Card'
+
+export { Modal, ConfirmationModal } from './Modal'
+export type { ModalProps } from './Modal'
+
+export { TextInput, SelectInput, FileUploadInput } from './Input'
+export type { TextInputProps, SelectInputProps, FileUploadInputProps } from './Input'
+
+export { Skeleton, CardSkeleton, TextSkeleton } from './Skeleton'
+export type { SkeletonProps } from './Skeleton'

--- a/frontend/src/lib/cn.ts
+++ b/frontend/src/lib/cn.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: Array<string | false | null | undefined>) {
+  return classes.filter(Boolean).join(' ')
+}


### PR DESCRIPTION
  ## Changes

  - Enabled environment-aware docs routing:
      - /docs enabled by default in development
      - docs disabled by default in production unless ENABLE_DOCS=true
      - ReDoc support added behind ENABLE_REDOC=true
  - Added API-level OpenAPI metadata:
      - richer API description
      - tag metadata for clearer grouping
      - Swagger UI settings (persistAuthorization, request duration display)
  - Added authentication documentation:
      - Bearer auth scheme (SupabaseBearerAuth, JWT format)
      - protected routes show auth requirement in Swagger
      - 401 auth response examples added on protected endpoints
  - Added endpoint docs:
      - detailed summary and description
      - request examples (JSON + multipart where applicable)
      - response and error examples

  ## Verification

  - Confirmed OpenAPI includes:
      - SupabaseBearerAuth security scheme
      - auth requirements on protected endpoints
      - request examples on updated routes
      - multipart example for clothing item creation
  - Confirmed route/config behavior:
      - docs route enabled in dev
      - ReDoc disabled by default
      - production defaults disable docs unless overridden

