### PR TITLE
Added backend sizing support 

### DIFF
--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -1,7 +1,7 @@
 """Pydantic schemas for request/response DTOs."""
 
-from pydantic import BaseModel, Field
-from typing import Optional, Tuple
+from pydantic import BaseModel, ConfigDict, Field
+from typing import Literal, Optional, Tuple
 from datetime import datetime
 
 
@@ -34,6 +34,24 @@ class Category(BaseModel):
     l2: str = Field(..., description="Level 2 category (e.g., T-Shirts, Jeans)")
 
 
+class Sizing(BaseModel):
+    """Flexible sizing payload stored as JSONB on clothing_items."""
+    model_config = ConfigDict(extra="allow")
+
+    mode: Optional[Literal["standard", "numeric", "measurements", "brand_specific", "hybrid"]] = None
+    standard_size: Optional[str] = None
+    numeric_size: Optional[float] = Field(None, ge=0)
+    numeric_type: Optional[Literal["dress", "pants_waist", "pants_waist_inseam"]] = None
+    numeric_system: Optional[Literal["US", "UK", "EU", "INT"]] = None
+    measurement_unit: Optional[Literal["cm", "in"]] = None
+    chest: Optional[float] = Field(None, ge=0)
+    waist: Optional[float] = Field(None, ge=0)
+    hips: Optional[float] = Field(None, ge=0)
+    inseam: Optional[float] = Field(None, ge=0)
+    brand_size_label: Optional[str] = None
+    size_notes: Optional[str] = None
+
+
 class ClothingItemBase(BaseModel):
     """Base clothing item fields - used in validation endpoints."""
     color: Color
@@ -46,6 +64,7 @@ class ClothingItemCreate(ClothingItemBase):
     """Clothing item with full metadata - used when saving to closet."""
     image_url: Optional[str] = None  # Optional - set after upload
     brand: Optional[str] = None
+    sizing: Optional[Sizing] = None
     price: Optional[float] = Field(None, ge=0)
     source_url: Optional[str] = None
     ownership: str = Field(default="owned", pattern=r"^(owned|wishlist)$")
@@ -57,6 +76,7 @@ class ClothingItemResponse(ClothingItemBase):
     user_id: str
     image_url: str
     brand: Optional[str] = None
+    sizing: Optional[Sizing] = None
     price: Optional[float] = None
     source_url: Optional[str] = None
     ownership: str = "owned"
@@ -227,6 +247,7 @@ class ClothingItemCreateRequest(BaseModel):
     formality: float = Field(..., ge=1.0, le=5.0)
     aesthetics: list[str] = Field(default_factory=list)
     brand: Optional[str] = None
+    sizing: Optional[Sizing] = None
     price: Optional[float] = Field(None, ge=0)
     source_url: Optional[str] = None
     ownership: str = Field(default="owned", pattern=r"^(owned|wishlist)$")

--- a/backend/app/routers/clothing_items.py
+++ b/backend/app/routers/clothing_items.py
@@ -147,6 +147,7 @@ async def create_clothing_item(
             formality=item_data.formality,
             aesthetics=item_data.aesthetics,
             brand=item_data.brand,
+            sizing=item_data.sizing,
             price=item_data.price,
             source_url=item_data.source_url,
             ownership=item_data.ownership,

--- a/backend/app/utils/constants.py
+++ b/backend/app/utils/constants.py
@@ -1,5 +1,9 @@
 """Constants for SIY application - categories, formality, aesthetics, and compatibility rules."""
 
+#=====================|
+# Algorithm Constants |
+#=====================|
+
 # Category Taxonomy (L1 -> L2)
 CATEGORY_TAXONOMY: dict[str, list[str]] = {
     "Tops": ["T-Shirts", "Polos", "Casual Shirts", "Dress Shirts", "Sweaters", "Hoodies", "Blazers"],
@@ -30,6 +34,8 @@ AESTHETIC_TAGS: list[str] = [
     "Vintage",
     "Edgy",
 ]
+
+# Color constants
 
 # Neutral colors that always work together
 # todo: some of these neutral colors don't have canonical HSL values
@@ -70,3 +76,42 @@ REQUIRED_CATEGORIES_FULLBODY: list[str] = ["Full Body", "Shoes"]
 MAX_OUTFIT_ITEMS: int = 6
 MAX_ACCESSORIES: int = 3
 MAX_OUTERWEAR: int = 1
+
+
+# Sizing
+STANDARD_SIZES: list[str] = ["XS", "S", "M", "L", "XL", "XXL"]
+
+STANDARD_SIZE_ORDER: dict[str, int] = {
+    "XS": 1,
+    "S": 2,
+    "M": 3,
+    "L": 4,
+    "XL": 5,
+    "XXL": 6,
+}
+
+SIZE_INPUT_MODES: list[str] = [
+    "standard",
+    "numeric",
+    "measurements",
+    "brand_specific",
+    "hybrid",
+]
+
+NUMERIC_SIZE_TYPES: list[str] = ["dress", "pants_waist", "pants_waist_inseam"]
+NUMERIC_SIZE_SYSTEMS: list[str] = ["US", "UK", "EU"]
+
+MEASUREMENT_UNITS: list[str] = ["cm", "in"]
+MEASUREMENT_FIELDS_CM: list[str] = ["chest_cm", "waist_cm", "hips_cm", "inseam_cm"]
+
+INCH_TO_CM: float = 2.54
+CM_TO_INCH: float = 1 / INCH_TO_CM
+
+MEASUREMENT_RANGE_CM: dict[str, tuple[float, float]] = {
+    "chest_cm": (70.0, 155.0),
+    "waist_cm": (50.0, 150.0),
+    "hips_cm": (75.0, 155.0),
+    "inseam_cm": (55.0, 100.0),
+}
+
+BRAND_SIZE_LABEL_MAX_LENGTH: int = 20

--- a/backend/supabase_schema.sql
+++ b/backend/supabase_schema.sql
@@ -75,6 +75,7 @@ CREATE TABLE IF NOT EXISTS public.clothing_items (
     
     -- Optional metadata
     brand TEXT,
+    sizing JSONB,
     price DECIMAL(10, 2),
     source_url TEXT,
     ownership TEXT DEFAULT 'owned' CHECK (ownership IN ('owned', 'wishlist')),
@@ -85,6 +86,11 @@ CREATE TABLE IF NOT EXISTS public.clothing_items (
 -- Indexes for clothing_items
 CREATE INDEX idx_clothing_items_user_id ON public.clothing_items(user_id);
 CREATE INDEX idx_clothing_items_category ON public.clothing_items(category_l1, category_l2);
+
+-- Sizing backfill migration
+ALTER TABLE public.clothing_items
+    ADD COLUMN IF NOT EXISTS sizing JSONB;
+
 
 -- Enable RLS
 ALTER TABLE public.clothing_items ENABLE ROW LEVEL SECURITY;

--- a/frontend/src/app/style/components/AddItemPanel.tsx
+++ b/frontend/src/app/style/components/AddItemPanel.tsx
@@ -69,6 +69,7 @@ export default function AddItemPanel({
     confirmAddItem,
     setTryOnResult,
     setAddingItemBrand,
+    setAddingItemSize,
     setAddingItemPrice,
     setAddingItemSourceUrl,
     setAddingItemOwnership,
@@ -524,6 +525,7 @@ export default function AddItemPanel({
 
   const optionalCount = [
     addingItem.brand,
+    addingItem.size,
     addingItem.price,
     addingItem.sourceUrl,
   ].filter(Boolean).length
@@ -744,6 +746,15 @@ export default function AddItemPanel({
                       value={addingItem.brand}
                       onChange={(e) => setAddingItemBrand(e.target.value)}
                       placeholder="e.g. Uniqlo, A.P.C."
+                      className="w-full bg-transparent border-b border-ink py-2 font-display italic text-[16px] text-ink placeholder:text-ink-3 placeholder:not-italic placeholder:font-mono placeholder:text-[12px] placeholder:tracking-[0.04em] focus:outline-none"
+                    />
+                  </EditorialField>
+                  <EditorialField label="Size">
+                    <input
+                      type="text"
+                      value={addingItem.size}
+                      onChange={(e) => setAddingItemSize(e.target.value)}
+                      placeholder="e.g. M, 32, 10.5"
                       className="w-full bg-transparent border-b border-ink py-2 font-display italic text-[16px] text-ink placeholder:text-ink-3 placeholder:not-italic placeholder:font-mono placeholder:text-[12px] placeholder:tracking-[0.04em] focus:outline-none"
                     />
                   </EditorialField>

--- a/frontend/src/app/style/components/MetadataStep.tsx
+++ b/frontend/src/app/style/components/MetadataStep.tsx
@@ -17,6 +17,7 @@ export default function MetadataStep() {
     aesthetics,
     ownership,
     brand,
+    size,
     price,
     sourceUrl,
     setCategory,
@@ -25,6 +26,7 @@ export default function MetadataStep() {
     toggleAesthetic,
     setOwnership,
     setBrand,
+    setSize,
     setPrice,
     setSourceUrl,
     setStep,
@@ -39,7 +41,7 @@ export default function MetadataStep() {
     [isMetadataValid, setStep],
   )
 
-  const optionalCount = [brand, price, sourceUrl].filter(Boolean).length
+  const optionalCount = [brand, size, price, sourceUrl].filter(Boolean).length
 
   return (
     <div className="py-12 max-md:py-8">
@@ -136,6 +138,13 @@ export default function MetadataStep() {
                   value={brand}
                   onChange={(e) => setBrand(e.target.value)}
                   placeholder="e.g. Uniqlo, Aimé Leon Dore"
+                />
+                <TextInput
+                  label="Size"
+                  type="text"
+                  value={size}
+                  onChange={(e) => setSize(e.target.value)}
+                  placeholder="e.g. M, 32, 10.5"
                 />
                 <TextInput
                   label="Price"

--- a/frontend/src/store/styleStore.ts
+++ b/frontend/src/store/styleStore.ts
@@ -58,6 +58,7 @@ export interface AddingItemState {
   aesthetics: string[]
   ownership: 'owned' | 'wishlist'
   brand: string
+  size: string
   price: string
   sourceUrl: string
   detectedColors: DetectedColor[]
@@ -79,6 +80,7 @@ const initialAddingItemState: AddingItemState = {
   aesthetics: [],
   ownership: 'owned',
   brand: '',
+  size: '',
   price: '',
   sourceUrl: '',
   detectedColors: [],
@@ -106,6 +108,7 @@ interface StyleState {
   aesthetics: string[]
   ownership: 'owned' | 'wishlist'
   brand: string
+  size: string
   price: string  // Store as string for input, convert to number when needed
   sourceUrl: string
   
@@ -156,6 +159,7 @@ interface StyleState {
   toggleAesthetic: (tag: string) => void
   setOwnership: (value: 'owned' | 'wishlist') => void
   setBrand: (value: string) => void
+  setSize: (value: string) => void
   setPrice: (value: string) => void
   setSourceUrl: (value: string) => void
   setDetectedColors: (colors: DetectedColor[]) => void
@@ -175,6 +179,7 @@ interface StyleState {
   toggleAddingItemAesthetic: (tag: string) => void
   setAddingItemOwnership: (value: 'owned' | 'wishlist') => void
   setAddingItemBrand: (value: string) => void
+  setAddingItemSize: (value: string) => void
   setAddingItemPrice: (value: string) => void
   setAddingItemSourceUrl: (value: string) => void
   setAddingItemDetectedColors: (colors: DetectedColor[]) => void
@@ -206,6 +211,7 @@ const initialState = {
   aesthetics: [] as string[],
   ownership: 'owned' as const,
   brand: '',
+  size: '',
   price: '',
   sourceUrl: '',
   detectedColors: [] as DetectedColor[],
@@ -254,6 +260,9 @@ export const useStyleStore = create<StyleState>((set, get) => ({
     if (state.brand.trim()) {
       item.brand = state.brand.trim()
     }
+    if (state.size.trim()) {
+      item.sizing = { mode: 'standard', standard_size: state.size.trim() }
+    }
     if (state.price.trim()) {
       const priceNum = parseFloat(state.price)
       if (!isNaN(priceNum) && priceNum >= 0) {
@@ -263,7 +272,7 @@ export const useStyleStore = create<StyleState>((set, get) => ({
     if (state.sourceUrl.trim()) {
       item.source_url = state.sourceUrl.trim()
     }
-    
+
     return item
   },
 
@@ -415,9 +424,11 @@ export const useStyleStore = create<StyleState>((set, get) => ({
   setOwnership: (ownership) => set({ ownership }),
   
   setBrand: (brand) => set({ brand }),
-  
+
+  setSize: (size) => set({ size }),
+
   setPrice: (price) => set({ price }),
-  
+
   setSourceUrl: (sourceUrl) => set({ sourceUrl }),
 
   // ---------------------------------------------------------------------------
@@ -545,6 +556,10 @@ export const useStyleStore = create<StyleState>((set, get) => ({
     addingItem: { ...state.addingItem, brand }
   })),
 
+  setAddingItemSize: (size) => set((state) => ({
+    addingItem: { ...state.addingItem, size }
+  })),
+
   setAddingItemPrice: (price) => set((state) => ({
     addingItem: { ...state.addingItem, price }
   })),
@@ -611,6 +626,9 @@ export const useStyleStore = create<StyleState>((set, get) => ({
     if (addingItem.brand.trim()) {
       newItem.brand = addingItem.brand.trim()
     }
+    if (addingItem.size.trim()) {
+      newItem.sizing = { mode: 'standard', standard_size: addingItem.size.trim() }
+    }
     if (addingItem.price.trim()) {
       const priceNum = parseFloat(addingItem.price)
       if (!isNaN(priceNum) && priceNum >= 0) {
@@ -669,6 +687,7 @@ export const useStyleStore = create<StyleState>((set, get) => ({
       aesthetics: item.aesthetics,
       ownership: item.ownership as 'owned' | 'wishlist',
       brand: item.brand || undefined,
+      sizing: item.sizing || undefined,
       price: item.price || undefined,
       source_url: item.source_url || undefined,
     }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -25,6 +25,21 @@ export interface Category {
   l2: string  // e.g., "T-Shirts", "Jeans"
 }
 
+export interface Sizing {
+  mode?: 'standard' | 'numeric' | 'measurements' | 'brand_specific' | 'hybrid'
+  standard_size?: string
+  numeric_size?: number
+  numeric_type?: 'dress' | 'pants_waist' | 'pants_waist_inseam'
+  numeric_system?: 'US' | 'UK' | 'EU' | 'INT'
+  measurement_unit?: 'cm' | 'in'
+  chest?: number
+  waist?: number
+  hips?: number
+  inseam?: number
+  brand_size_label?: string
+  size_notes?: string
+}
+
 export interface ClothingItemBase {
   color: Color
   category: Category
@@ -35,6 +50,7 @@ export interface ClothingItemBase {
 export interface ClothingItemCreate extends ClothingItemBase {
   image_url?: string  // Optional - set after upload
   brand?: string
+  sizing?: Sizing
   price?: number
   source_url?: string
   ownership?: 'owned' | 'wishlist'
@@ -45,6 +61,7 @@ export interface ClothingItemResponse extends ClothingItemBase {
   user_id: string
   image_url: string
   brand?: string
+  sizing?: Sizing
   price?: number
   source_url?: string
   ownership: 'owned' | 'wishlist'
@@ -202,6 +219,7 @@ export interface ClothingItemCreateRequest {
   formality: number
   aesthetics: string[]
   brand?: string
+  sizing?: Sizing
   price?: number
   source_url?: string
   ownership?: 'owned' | 'wishlist'


### PR DESCRIPTION
Closes #6 

 ### Changes

  - Added sizing as a nullable JSONB field on public.clothing_items in supabase_schema.sql.
  - Added a new Sizing Pydantic model in app/models/schemas.py.
  - Added optional sizing to:
      - ClothingItemCreate
      - ClothingItemResponse
      - ClothingItemCreateRequest
  - Wired sizing through create flow in app/routers/clothing_items.py.
  - Wired sizing read/write/update mapping in app/services/supabase.py:
      - insert payload includes serialized sizing
      - update supports sizing objects
      - DB row mapping hydrates sizing into response model
  - Added/updated unit tests in tests/unit/test_supabase.py for:
      - DB row -> response sizing mapping
      - create payload sizing serialization
      - update payload sizing serialization

  ### Backward compatibility

  - Old frontend requests that omit size continue to work.
  - sizing is optional in request/response models and persists as NULL when not provided.
