### PR TITLE
fix(color): rebuild color recommendation pipeline end-to-end

### DIFF
--- a/backend/app/services/color_harmony.py
+++ b/backend/app/services/color_harmony.py
@@ -1,14 +1,20 @@
 """Color harmony calculations and utilities.
 uses the HSL (Hue, Saturation, Lightness) color model to mathematically determine if colors look good together and to generate matching color palettes."""
-from pyparsing import Literal
 
 from app.models.schemas import HSL, Color, RecommendedColor
 from app.utils.constants import NEUTRAL_COLORS, NEUTRAL_COLOR_DATA
 
 
+# British/American spelling alias so "grey" still classifies as neutral
+# without having to duplicate the entry in NEUTRAL_COLORS / NEUTRAL_COLOR_DATA.
+_NEUTRAL_NAME_ALIASES = {"grey": "gray"}
+
+
 def is_neutral_color(color_name: str) -> bool:
     """Check if a color name is considered neutral."""
-    return color_name.lower() in NEUTRAL_COLORS
+    name = color_name.lower()
+    name = _NEUTRAL_NAME_ALIASES.get(name, name)
+    return name in NEUTRAL_COLORS
 
 
 

--- a/backend/app/services/color_harmony.py
+++ b/backend/app/services/color_harmony.py
@@ -256,7 +256,11 @@ def generate_recommended_colors(base_color: Color, include_neutrals: bool = True
         ]
 
     if include_neutrals:
+        # Seed with already-generated harmonies AND the base color itself so we
+        # never recommend the same color the user uploaded (e.g. navy base
+        # would otherwise suggest navy from the neutral set).
         seen_hex: set[str] = {c.hex.lower() for c in recommended_colors}
+        seen_hex.add(base_color.hex.lower())
 
         for name in NEUTRAL_COLORS:
             data = NEUTRAL_COLOR_DATA.get(name)

--- a/backend/app/services/color_harmony.py
+++ b/backend/app/services/color_harmony.py
@@ -204,6 +204,14 @@ def get_analogous_hsl(base_hsl: HSL) -> tuple[HSL, HSL]:
 
     return hsl1, hsl2
 
+def get_triadic_hsl(base_hsl: HSL) -> tuple[HSL, HSL]:
+    """Generate triadic colors (±120° from base)."""
+    h, s, l = base_hsl.get_hsl()
+    h1 = (h + 120) % 360
+    h2 = (h - 120) % 360
+    return HSL(h=h1, s=s, l=l), HSL(h=h2, s=s, l=l)
+
+
 def get_complementary_hsl(base_hsl: HSL) -> HSL:
     """Get the complementary color (180° opposite)."""
     h,s,l = base_hsl.get_hsl()
@@ -248,11 +256,14 @@ def generate_recommended_colors(base_color: Color, include_neutrals: bool = True
     if baseHSL.s >= 10:
         anal1, anal2 = get_analogous_hsl(baseHSL)
         comp = get_complementary_hsl(baseHSL)
+        tri1, tri2 = get_triadic_hsl(baseHSL)
 
         recommended_colors += [
             hsl_to_rec(anal1, "analogous"),
             hsl_to_rec(anal2, "analogous"),
             hsl_to_rec(comp, "complementary"),
+            hsl_to_rec(tri1, "triadic"),
+            hsl_to_rec(tri2, "triadic"),
         ]
 
     if include_neutrals:

--- a/backend/app/services/color_harmony.py
+++ b/backend/app/services/color_harmony.py
@@ -258,12 +258,22 @@ def generate_recommended_colors(base_color: Color, include_neutrals: bool = True
         comp = get_complementary_hsl(baseHSL)
         tri1, tri2 = get_triadic_hsl(baseHSL)
 
+        # When the base is at the lightness extremes (very dark or very light),
+        # generated harmonies that share that lightness look muddy or washed
+        # out. Pull them toward the mid range so the harmony relationship
+        # actually reads visually.
+        def _balance_lightness(hsl: HSL) -> HSL:
+            balanced_l = max(25, min(75, hsl.l))
+            if balanced_l == hsl.l:
+                return hsl
+            return HSL(h=hsl.h, s=hsl.s, l=balanced_l)
+
         recommended_colors += [
-            hsl_to_rec(anal1, "analogous"),
-            hsl_to_rec(anal2, "analogous"),
-            hsl_to_rec(comp, "complementary"),
-            hsl_to_rec(tri1, "triadic"),
-            hsl_to_rec(tri2, "triadic"),
+            hsl_to_rec(_balance_lightness(anal1), "analogous"),
+            hsl_to_rec(_balance_lightness(anal2), "analogous"),
+            hsl_to_rec(_balance_lightness(comp), "complementary"),
+            hsl_to_rec(_balance_lightness(tri1), "triadic"),
+            hsl_to_rec(_balance_lightness(tri2), "triadic"),
         ]
 
     if include_neutrals:

--- a/backend/app/services/color_harmony.py
+++ b/backend/app/services/color_harmony.py
@@ -228,12 +228,12 @@ def generate_recommended_colors(base_color: Color, include_neutrals: bool = True
     3. Return list of RecommendedColor objects
     """
 
-    def hsl_to_rec(rec_hsl: HSL) -> RecommendedColor:
+    def hsl_to_rec(rec_hsl: HSL, harmony: str) -> RecommendedColor:
+        # Label by generation intent, not by re-deriving from check_color_compatibility.
+        # The latter short-circuits to "neutral" whenever either input has a neutral
+        # name (e.g. navy base), masking the actual analogous/complementary relationship.
         hex = hsl_to_hex(rec_hsl)
-        recColor = hsl_to_color(rec_hsl)
-        rec_name = recColor.name
-        harmony = check_color_compatibility(base_color, recColor)[1]
-
+        rec_name = get_color_name_from_hsl(rec_hsl)
         return RecommendedColor(hex=hex, name=rec_name, harmony_type=harmony)
 
 
@@ -258,14 +258,18 @@ def generate_recommended_colors(base_color: Color, include_neutrals: bool = True
             seen_hex.add(hx)
 
 
-    # TODO: do something here
-    if is_neutral_color(base_color.name):
-        pass
-    else:
+    # Skip harmony generation only for truly achromatic bases (gray/black/white).
+    # Chromatic "fashion neutrals" like navy/beige/tan/khaki have meaningful hue
+    # and should still receive analogous/complementary picks.
+    if baseHSL.s >= 10:
         anal1, anal2 = get_analogous_hsl(baseHSL)
         comp = get_complementary_hsl(baseHSL)
 
-        non_neutral_recs = [hsl_to_rec(anal1), hsl_to_rec(anal2), hsl_to_rec(comp)]
+        non_neutral_recs = [
+            hsl_to_rec(anal1, "analogous"),
+            hsl_to_rec(anal2, "analogous"),
+            hsl_to_rec(comp, "complementary"),
+        ]
         recommended_colors += non_neutral_recs
 
     return recommended_colors

--- a/backend/app/services/color_harmony.py
+++ b/backend/app/services/color_harmony.py
@@ -241,7 +241,20 @@ def generate_recommended_colors(base_color: Color, include_neutrals: bool = True
     recommended_colors : list[RecommendedColor] = []
     baseHSL : HSL = base_color.hsl
 
-    # TODO: Look into adding all the neutral colors
+    # Harmonies first — they're the differentiator and should lead the list.
+    # Neutrals are appended after as the safe fallback set. Skip harmony
+    # generation only for truly achromatic bases (gray/black/white); chromatic
+    # "fashion neutrals" like navy/beige/tan/khaki have meaningful hue.
+    if baseHSL.s >= 10:
+        anal1, anal2 = get_analogous_hsl(baseHSL)
+        comp = get_complementary_hsl(baseHSL)
+
+        recommended_colors += [
+            hsl_to_rec(anal1, "analogous"),
+            hsl_to_rec(anal2, "analogous"),
+            hsl_to_rec(comp, "complementary"),
+        ]
+
     if include_neutrals:
         seen_hex: set[str] = {c.hex.lower() for c in recommended_colors}
 
@@ -256,20 +269,5 @@ def generate_recommended_colors(base_color: Color, include_neutrals: bool = True
                 RecommendedColor(hex=hx, name=name, harmony_type="neutral")
             )
             seen_hex.add(hx)
-
-
-    # Skip harmony generation only for truly achromatic bases (gray/black/white).
-    # Chromatic "fashion neutrals" like navy/beige/tan/khaki have meaningful hue
-    # and should still receive analogous/complementary picks.
-    if baseHSL.s >= 10:
-        anal1, anal2 = get_analogous_hsl(baseHSL)
-        comp = get_complementary_hsl(baseHSL)
-
-        non_neutral_recs = [
-            hsl_to_rec(anal1, "analogous"),
-            hsl_to_rec(anal2, "analogous"),
-            hsl_to_rec(comp, "complementary"),
-        ]
-        recommended_colors += non_neutral_recs
 
     return recommended_colors

--- a/backend/app/services/compatibility.py
+++ b/backend/app/services/compatibility.py
@@ -558,11 +558,12 @@ def generate_category_recommendations(
     
     # Exclude already filled categories
     categories_to_recommend = [cat for cat in categories_to_recommend if cat not in filled_categories]
-    
+
+    # Colors don't depend on the slot category — compute once and reuse.
+    colors = generate_recommended_colors(base_item.color, include_neutrals=True)
+
     # 2. For each category to recommend
     for category_l1 in categories_to_recommend:
-        # Generate colors
-        colors = generate_recommended_colors(base_item.color, include_neutrals=True)
         
         # Calculate formality range: base ± 1, clamped to 1-5
         # VALIDATION FIX: Explicitly handle float formality

--- a/backend/app/utils/constants.py
+++ b/backend/app/utils/constants.py
@@ -40,7 +40,7 @@ AESTHETIC_TAGS: list[str] = [
 # Neutral colors that always work together
 # todo: some of these neutral colors don't have canonical HSL values
 NEUTRAL_COLORS: list[str] = [
-    "black", "white", "gray", "grey", "navy", "beige", "cream", "tan", "khaki"
+    "black", "white", "gray", "navy", "beige", "cream", "tan", "khaki"
 ]
 
 # str to Color mappings:
@@ -48,7 +48,6 @@ NEUTRAL_COLOR_DATA: dict[str, dict] = {
     "black": {"hex": "#000000", "hsl": (0, 0, 0)},
     "white": {"hex": "#FFFFFF", "hsl": (0, 0, 100)},
     "gray":  {"hex": "#808080", "hsl": (0, 0, 50)},
-    "grey":  {"hex": "#808080", "hsl": (0, 0, 50)},
     "navy":  {"hex": "#0B1C2D", "hsl": (210, 61, 11)},
     "beige": {"hex": "#F5F5DC", "hsl": (60, 56, 91)},
     "cream": {"hex": "#FFFDD0", "hsl": (57, 100, 91)},

--- a/backend/tests/unit/test_color_harmony.py
+++ b/backend/tests/unit/test_color_harmony.py
@@ -242,14 +242,34 @@ def test_generate_recommended_colors_without_neutrals():
     assert len([rec for rec in recommendations if rec.harmony_type == "complementary"]) == 1
 
 
-def test_generate_recommended_colors_for_neutral_base():
+def test_generate_recommended_colors_for_achromatic_base():
+    """Achromatic neutrals (s≈0) have no meaningful hue — skip harmony generation."""
     base = Color(hex="#FFFFFF", hsl=HSL(h=0, s=0, l=100), name="white", is_neutral=True)
     recommendations = color_harmony.generate_recommended_colors(base, include_neutrals=True)
     assert [rec for rec in recommendations if rec.harmony_type != "neutral"] == []
     assert {"white", "black", "gray", "navy", "beige"}.issubset({rec.name for rec in recommendations})
 
 
-def test_generate_recommended_colors_for_neutral_base_without_neutrals():
+def test_generate_recommended_colors_for_achromatic_base_without_neutrals():
     base = Color(hex="#FFFFFF", hsl=HSL(h=0, s=0, l=100), name="white", is_neutral=True)
     recommendations = color_harmony.generate_recommended_colors(base, include_neutrals=False)
     assert recommendations == []
+
+
+def test_generate_recommended_colors_for_chromatic_neutral_base_navy():
+    """Navy is in NEUTRAL_COLORS but has meaningful hue (h=210, s=61) — must get harmonies."""
+    base = Color(hex="#0B1C2D", hsl=HSL(h=210, s=61, l=11), name="navy", is_neutral=True)
+    recommendations = color_harmony.generate_recommended_colors(base, include_neutrals=True)
+    analogs = [rec for rec in recommendations if rec.harmony_type == "analogous"]
+    complementary = [rec for rec in recommendations if rec.harmony_type == "complementary"]
+    assert len(analogs) == 2
+    assert len(complementary) == 1
+
+
+def test_generate_recommended_colors_for_chromatic_neutral_base_beige():
+    base = Color(hex="#F5F5DC", hsl=HSL(h=60, s=56, l=91), name="beige", is_neutral=True)
+    recommendations = color_harmony.generate_recommended_colors(base, include_neutrals=False)
+    analogs = [rec for rec in recommendations if rec.harmony_type == "analogous"]
+    complementary = [rec for rec in recommendations if rec.harmony_type == "complementary"]
+    assert len(analogs) == 2
+    assert len(complementary) == 1

--- a/backend/tests/unit/test_color_harmony.py
+++ b/backend/tests/unit/test_color_harmony.py
@@ -214,6 +214,28 @@ def test_get_complementary_hsl_expected_hues(base_h: int, expected_h: int):
     assert (result.s, result.l) == (55, 45)
 
 
+def test_get_triadic_hsl_wraps_and_preserves_sl():
+    base = HSL(h=10, s=40, l=60)
+    result = color_harmony.get_triadic_hsl(base)
+    assert len(result) == 2
+    assert {result[0].h, result[1].h} == {130, 250}
+    for hsl in result:
+        assert (hsl.s, hsl.l) == (40, 60)
+
+
+def test_get_triadic_hsl_wraps_low_end():
+    base = HSL(h=350, s=70, l=40)
+    result = color_harmony.get_triadic_hsl(base)
+    assert {result[0].h, result[1].h} == {110, 230}
+
+
+def test_generate_recommended_colors_includes_triadic_for_chromatic_base():
+    base = Color(hex="#FF0000", hsl=HSL(h=0, s=100, l=50), name="red", is_neutral=False)
+    recs = color_harmony.generate_recommended_colors(base, include_neutrals=False)
+    triadic = [rec for rec in recs if rec.harmony_type == "triadic"]
+    assert len(triadic) == 2
+
+
 def test_generate_recommended_colors_includes_neutrals_and_harmonies():
     base = Color(hex="#FF0000", hsl=HSL(h=0, s=100, l=50), name="red", is_neutral=False)
     recommendations = color_harmony.generate_recommended_colors(base, include_neutrals=True)
@@ -224,7 +246,12 @@ def test_generate_recommended_colors_includes_neutrals_and_harmonies():
     assert {"white", "black", "gray", "navy", "beige"}.issubset({rec.name for rec in neutrals})
     assert len(analogs) == 2
     assert len(complementary) == 1
-    assert {rec.harmony_type for rec in recommendations} <= {"neutral", "analogous", "complementary"}
+    assert {rec.harmony_type for rec in recommendations} <= {
+        "neutral",
+        "analogous",
+        "complementary",
+        "triadic",
+    }
 
     analog_expected = {
         ("orange", "#FF7F00"),

--- a/backend/tests/unit/test_color_harmony.py
+++ b/backend/tests/unit/test_color_harmony.py
@@ -243,11 +243,14 @@ def test_generate_recommended_colors_without_neutrals():
 
 
 def test_generate_recommended_colors_for_achromatic_base():
-    """Achromatic neutrals (s≈0) have no meaningful hue — skip harmony generation."""
+    """Achromatic neutrals (s≈0) have no meaningful hue — skip harmony generation.
+    The base color itself is also excluded from the neutral list (no white-on-white)."""
     base = Color(hex="#FFFFFF", hsl=HSL(h=0, s=0, l=100), name="white", is_neutral=True)
     recommendations = color_harmony.generate_recommended_colors(base, include_neutrals=True)
     assert [rec for rec in recommendations if rec.harmony_type != "neutral"] == []
-    assert {"white", "black", "gray", "navy", "beige"}.issubset({rec.name for rec in recommendations})
+    names = {rec.name for rec in recommendations}
+    assert {"black", "gray", "navy", "beige"}.issubset(names)
+    assert "white" not in names
 
 
 def test_generate_recommended_colors_for_achromatic_base_without_neutrals():
@@ -273,6 +276,20 @@ def test_generate_recommended_colors_for_chromatic_neutral_base_beige():
     complementary = [rec for rec in recommendations if rec.harmony_type == "complementary"]
     assert len(analogs) == 2
     assert len(complementary) == 1
+
+
+def test_generate_recommended_colors_excludes_base_hex_from_neutrals():
+    """Navy base must not be told to wear navy with itself."""
+    base = Color(hex="#0B1C2D", hsl=HSL(h=210, s=61, l=11), name="navy", is_neutral=True)
+    recs = color_harmony.generate_recommended_colors(base, include_neutrals=True)
+    assert all(rec.hex.lower() != "#0b1c2d" for rec in recs)
+
+
+def test_generate_recommended_colors_excludes_base_hex_case_insensitive():
+    """Same dedup regardless of base hex letter case."""
+    base = Color(hex="#0b1c2d", hsl=HSL(h=210, s=61, l=11), name="navy", is_neutral=True)
+    recs = color_harmony.generate_recommended_colors(base, include_neutrals=True)
+    assert all(rec.hex.lower() != "#0b1c2d" for rec in recs)
 
 
 def test_generate_recommended_colors_harmonies_come_before_neutrals():

--- a/backend/tests/unit/test_color_harmony.py
+++ b/backend/tests/unit/test_color_harmony.py
@@ -236,6 +236,26 @@ def test_generate_recommended_colors_includes_triadic_for_chromatic_base():
     assert len(triadic) == 2
 
 
+def test_generate_recommended_colors_clamps_lightness_for_dark_base():
+    """A very dark navy base (l=11) would otherwise produce muddy dark harmonies.
+    Generated picks should land in a visually usable lightness range."""
+    base = Color(hex="#0B1C2D", hsl=HSL(h=210, s=61, l=11), name="navy", is_neutral=True)
+    recs = color_harmony.generate_recommended_colors(base, include_neutrals=False)
+    for rec in recs:
+        r, g, b = int(rec.hex[1:3], 16), int(rec.hex[3:5], 16), int(rec.hex[5:7], 16)
+        # Naive perceived lightness — anything brighter than the original navy.
+        assert max(r, g, b) > 0x2D
+
+
+def test_generate_recommended_colors_clamps_lightness_for_light_base():
+    base = Color(hex="#F5F5DC", hsl=HSL(h=60, s=56, l=91), name="beige", is_neutral=True)
+    recs = color_harmony.generate_recommended_colors(base, include_neutrals=False)
+    for rec in recs:
+        r, g, b = int(rec.hex[1:3], 16), int(rec.hex[3:5], 16), int(rec.hex[5:7], 16)
+        # Should not all be near-white (every channel >= 0xE0 would be washed out).
+        assert min(r, g, b) < 0xE0 or max(r, g, b) - min(r, g, b) > 0x20
+
+
 def test_generate_recommended_colors_includes_neutrals_and_harmonies():
     base = Color(hex="#FF0000", hsl=HSL(h=0, s=100, l=50), name="red", is_neutral=False)
     recommendations = color_harmony.generate_recommended_colors(base, include_neutrals=True)

--- a/backend/tests/unit/test_color_harmony.py
+++ b/backend/tests/unit/test_color_harmony.py
@@ -273,3 +273,14 @@ def test_generate_recommended_colors_for_chromatic_neutral_base_beige():
     complementary = [rec for rec in recommendations if rec.harmony_type == "complementary"]
     assert len(analogs) == 2
     assert len(complementary) == 1
+
+
+def test_generate_recommended_colors_harmonies_come_before_neutrals():
+    """Harmony picks lead the list so they surface first in the UI and the
+    example string in compatibility.py picks a harmony color, not 'black'."""
+    base = Color(hex="#FF0000", hsl=HSL(h=0, s=100, l=50), name="red", is_neutral=False)
+    recs = color_harmony.generate_recommended_colors(base, include_neutrals=True)
+    first_neutral_idx = next(i for i, r in enumerate(recs) if r.harmony_type == "neutral")
+    harmony_indices = [i for i, r in enumerate(recs) if r.harmony_type != "neutral"]
+    assert all(i < first_neutral_idx for i in harmony_indices)
+    assert recs[0].harmony_type != "neutral"

--- a/frontend/src/app/style/components/AddItemPanel.tsx
+++ b/frontend/src/app/style/components/AddItemPanel.tsx
@@ -123,11 +123,23 @@ export default function AddItemPanel({
     }
   }, [recommendation, currentStep, setAddingItemFormality])
 
+  // Track the last suggestion hex we auto-applied. Without this, navigating
+  // back to 'metadata' and forward to 'colors' would silently re-override
+  // whatever color the user picked in between.
+  const lastAppliedSuggestionRef = useRef<string | null>(null)
+
   useEffect(() => {
-    if (suggestedColor && currentStep === 'colors') {
-      setAddingItemAdjustedColor(buildColorFromHex(suggestedColor.hex))
-    }
+    if (!suggestedColor || currentStep !== 'colors') return
+    const hex = suggestedColor.hex.toLowerCase()
+    if (lastAppliedSuggestionRef.current === hex) return
+    setAddingItemAdjustedColor(buildColorFromHex(suggestedColor.hex))
+    lastAppliedSuggestionRef.current = hex
   }, [suggestedColor, currentStep, setAddingItemAdjustedColor])
+
+  const isSuggestionApplied =
+    !!suggestedColor &&
+    addingItem.adjustedColor?.hex.toLowerCase() ===
+      suggestedColor.hex.toLowerCase()
 
   const handleFileSelect = useCallback((file: File) => {
     setSelectedFile(file)
@@ -863,6 +875,24 @@ export default function AddItemPanel({
                 )}
               </div>
             </div>
+
+            {isSuggestionApplied && suggestedColor && (
+              <div className="flex items-center justify-between gap-3 px-3 py-2 border border-ink bg-paper-3">
+                <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-ink-3">
+                  Using suggested color
+                </span>
+                <div className="flex items-center gap-2">
+                  <i
+                    className="inline-block w-3 h-3 border border-ink"
+                    style={{ backgroundColor: suggestedColor.hex }}
+                    aria-hidden="true"
+                  />
+                  <span className="font-display italic text-[14px] leading-none">
+                    {suggestedColor.name}
+                  </span>
+                </div>
+              </div>
+            )}
 
             <ColorSelector
               detectedColors={addingItem.detectedColors.map((dc) => ({

--- a/frontend/src/app/style/components/BuildStep.tsx
+++ b/frontend/src/app/style/components/BuildStep.tsx
@@ -390,6 +390,7 @@ export default function BuildStep() {
               <SuggestionPanel
                 recommendation={getRecommendationForCategory(addingCategory!)}
                 categoryL1={addingCategory!}
+                selectedColor={selectedSuggestedColor}
                 onColorClick={handleSuggestedColorClick}
                 onQuickAdd={handleQuickAdd}
               />

--- a/frontend/src/app/style/components/shared/SuggestionPanel.tsx
+++ b/frontend/src/app/style/components/shared/SuggestionPanel.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react'
 import { useAuth } from '@/components/AuthProvider'
 import { getMatchingItems } from '@/lib/api'
+import { cn } from '@/lib/cn'
 import type {
   CategoryRecommendation,
   RecommendedColor,
@@ -13,6 +14,7 @@ import { FORMALITY_LEVELS } from '@/types'
 interface SuggestionPanelProps {
   recommendation: CategoryRecommendation | null
   categoryL1: string
+  selectedColor?: RecommendedColor | null
   onColorClick?: (color: RecommendedColor) => void
   onQuickAdd?: (item: ClothingItemResponse) => void
 }
@@ -20,6 +22,7 @@ interface SuggestionPanelProps {
 export default function SuggestionPanel({
   recommendation,
   categoryL1,
+  selectedColor,
   onColorClick,
   onQuickAdd,
 }: SuggestionPanelProps) {
@@ -172,32 +175,54 @@ export default function SuggestionPanel({
             Recommended colors
           </div>
           <ul className="flex flex-col gap-2">
-            {recommendation.colors.map((color, i) => (
-              <li key={i}>
-                <button
-                  type="button"
-                  onClick={() => onColorClick?.(color)}
-                  className="w-full flex items-center gap-3 px-3 py-2 border border-ink bg-paper hover:bg-paper-2 transition-colors text-left"
-                >
-                  <i
-                    className="inline-block w-[20px] h-[20px] border border-ink shrink-0"
-                    style={{ backgroundColor: color.hex }}
-                    aria-hidden="true"
-                  />
-                  <div className="flex-1 min-w-0">
-                    <p className="font-display text-[15px] leading-none">
-                      {color.name}
-                    </p>
-                    <p className="font-mono text-[9px] uppercase tracking-[0.1em] text-ink-3 mt-1">
-                      {color.hex.toUpperCase()}
-                    </p>
-                  </div>
-                  <span className="font-mono text-[9px] uppercase tracking-[0.1em] text-ink-3 shrink-0">
-                    {color.harmony_type}
-                  </span>
-                </button>
-              </li>
-            ))}
+            {recommendation.colors.map((color, i) => {
+              const isActive =
+                selectedColor?.hex.toLowerCase() === color.hex.toLowerCase()
+              return (
+                <li key={i}>
+                  <button
+                    type="button"
+                    aria-pressed={isActive}
+                    onClick={() => onColorClick?.(color)}
+                    className={cn(
+                      'w-full flex items-center gap-3 px-3 py-2 border border-ink text-left transition-colors',
+                      isActive ? 'bg-paper-3' : 'bg-paper hover:bg-paper-2',
+                    )}
+                  >
+                    <span
+                      className={cn(
+                        'font-mono text-[10px] text-ink shrink-0 w-3 text-center',
+                        isActive ? 'opacity-100' : 'opacity-0',
+                      )}
+                      aria-hidden="true"
+                    >
+                      →
+                    </span>
+                    <i
+                      className="inline-block w-[20px] h-[20px] border border-ink shrink-0"
+                      style={{ backgroundColor: color.hex }}
+                      aria-hidden="true"
+                    />
+                    <div className="flex-1 min-w-0">
+                      <p
+                        className={cn(
+                          'font-display text-[15px] leading-none',
+                          isActive && 'font-bold',
+                        )}
+                      >
+                        {color.name}
+                      </p>
+                      <p className="font-mono text-[9px] uppercase tracking-[0.1em] text-ink-3 mt-1">
+                        {color.hex.toUpperCase()}
+                      </p>
+                    </div>
+                    <span className="font-mono text-[9px] uppercase tracking-[0.1em] text-ink-3 shrink-0">
+                      {color.harmony_type}
+                    </span>
+                  </button>
+                </li>
+              )
+            })}
           </ul>
         </section>
 

--- a/frontend/src/app/style/components/shared/SuggestionPanel.tsx
+++ b/frontend/src/app/style/components/shared/SuggestionPanel.tsx
@@ -170,61 +170,93 @@ export default function SuggestionPanel({
         {session?.access_token && <hr className="border-t border-rule-soft" />}
 
         {/* Recommended colors */}
-        <section>
-          <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-ink-3 mb-3">
-            Recommended colors
-          </div>
-          <ul className="flex flex-col gap-2">
-            {recommendation.colors.map((color, i) => {
-              const isActive =
-                selectedColor?.hex.toLowerCase() === color.hex.toLowerCase()
-              return (
-                <li key={i}>
-                  <button
-                    type="button"
-                    aria-pressed={isActive}
-                    onClick={() => onColorClick?.(color)}
+        {(() => {
+          const harmonies = recommendation.colors.filter(
+            (c) => c.harmony_type !== 'neutral',
+          )
+          const neutrals = recommendation.colors.filter(
+            (c) => c.harmony_type === 'neutral',
+          )
+
+          const renderColorButton = (color: RecommendedColor, key: string) => {
+            const isActive =
+              selectedColor?.hex.toLowerCase() === color.hex.toLowerCase()
+            return (
+              <li key={key}>
+                <button
+                  type="button"
+                  aria-pressed={isActive}
+                  onClick={() => onColorClick?.(color)}
+                  className={cn(
+                    'w-full flex items-center gap-3 px-3 py-2 border border-ink text-left transition-colors',
+                    isActive ? 'bg-paper-3' : 'bg-paper hover:bg-paper-2',
+                  )}
+                >
+                  <span
                     className={cn(
-                      'w-full flex items-center gap-3 px-3 py-2 border border-ink text-left transition-colors',
-                      isActive ? 'bg-paper-3' : 'bg-paper hover:bg-paper-2',
+                      'font-mono text-[10px] text-ink shrink-0 w-3 text-center',
+                      isActive ? 'opacity-100' : 'opacity-0',
                     )}
+                    aria-hidden="true"
                   >
-                    <span
+                    →
+                  </span>
+                  <i
+                    className="inline-block w-[20px] h-[20px] border border-ink shrink-0"
+                    style={{ backgroundColor: color.hex }}
+                    aria-hidden="true"
+                  />
+                  <div className="flex-1 min-w-0">
+                    <p
                       className={cn(
-                        'font-mono text-[10px] text-ink shrink-0 w-3 text-center',
-                        isActive ? 'opacity-100' : 'opacity-0',
+                        'font-display text-[15px] leading-none',
+                        isActive && 'font-bold',
                       )}
-                      aria-hidden="true"
                     >
-                      →
-                    </span>
-                    <i
-                      className="inline-block w-[20px] h-[20px] border border-ink shrink-0"
-                      style={{ backgroundColor: color.hex }}
-                      aria-hidden="true"
-                    />
-                    <div className="flex-1 min-w-0">
-                      <p
-                        className={cn(
-                          'font-display text-[15px] leading-none',
-                          isActive && 'font-bold',
-                        )}
-                      >
-                        {color.name}
-                      </p>
-                      <p className="font-mono text-[9px] uppercase tracking-[0.1em] text-ink-3 mt-1">
-                        {color.hex.toUpperCase()}
-                      </p>
-                    </div>
-                    <span className="font-mono text-[9px] uppercase tracking-[0.1em] text-ink-3 shrink-0">
-                      {color.harmony_type}
-                    </span>
-                  </button>
-                </li>
-              )
-            })}
-          </ul>
-        </section>
+                      {color.name}
+                    </p>
+                    <p className="font-mono text-[9px] uppercase tracking-[0.1em] text-ink-3 mt-1">
+                      {color.hex.toUpperCase()}
+                    </p>
+                  </div>
+                  <span className="font-mono text-[9px] uppercase tracking-[0.1em] text-ink-3 shrink-0">
+                    {color.harmony_type}
+                  </span>
+                </button>
+              </li>
+            )
+          }
+
+          return (
+            <>
+              {harmonies.length > 0 && (
+                <section>
+                  <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-ink-3 mb-3">
+                    Harmonies
+                  </div>
+                  <ul className="flex flex-col gap-2">
+                    {harmonies.map((color, i) =>
+                      renderColorButton(color, `h-${i}`),
+                    )}
+                  </ul>
+                </section>
+              )}
+
+              {neutrals.length > 0 && (
+                <section>
+                  <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-ink-3 mb-3">
+                    Neutrals
+                  </div>
+                  <ul className="flex flex-col gap-2">
+                    {neutrals.map((color, i) =>
+                      renderColorButton(color, `n-${i}`),
+                    )}
+                  </ul>
+                </section>
+              )}
+            </>
+          )
+        })()}
 
         <hr className="border-t border-rule-soft" />
 


### PR DESCRIPTION
## Summary

Fixes a cluster of logic and UX holes in color/item recommendation that surfaced during a verification pass. 

**Backend (services/color_harmony.py, services/compatibility.py, utils/constants.py)**
- Chromatic "fashion neutrals" (navy, beige, tan, khaki) now receive analogous/complementary/triadic picks — gated by saturation (`s >= 10`), not by name membership.
- Generated colors are labeled by *generation intent*, not re-derived via `check_color_compatibility` (which short-circuited to `"neutral"` whenever the base name was neutral and masked the actual relationship).
- Harmonies now lead the recommendation list; neutrals append after. Cascade-fix: the `example` string no longer always reads "X in black".
- Base color hex is excluded from the neutral list — no more "wear navy with your navy".
- New `get_triadic_hsl(base)` returning ±120° HSL pairs; `harmony_type="triadic"` now has a producer.
- Generated harmony lightness is clamped to `[25, 75]` so dark/light bases don't produce muddy or washed-out complementaries.
- Hygiene: dropped unused `from pyparsing import Literal`, deduped `gray`/`grey` via alias normalization in `is_neutral_color`, hoisted the per-category `generate_recommended_colors` call.

**Frontend (style/components)**
- `SuggestionPanel` now shows visible selected state (`aria-pressed`, `→` marker, `bg-paper-3`, `font-bold`) on the recommended color button matching `selectedSuggestedColor`.
- Recommendations grouped under "Harmonies" and "Neutrals" subheadings instead of one flat list of ~12.
- `AddItemPanel` no longer silently re-applies the suggestion when the user navigates back to the color step. A ref tracks the last-applied hex; a visible "Using suggested color" banner surfaces above the color selector whenever the current adjusted color came from a suggestion.
