### PR TITLE
feat(matching): closet escape hatch when nothing meets recommendations

### DIFF
--- a/backend/app/routers/closet.py
+++ b/backend/app/routers/closet.py
@@ -16,7 +16,7 @@ from app.models.schemas import (
     FormalityRange,
 )
 from app.services.supabase import get_closet as get_closet_from_db, get_user_clothing_items
-from app.services.matching import filter_and_rank_items
+from app.services.matching import rank_items_in_category
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +48,13 @@ class MatchingItemsRequest(BaseModel):
 class MatchingItemsResponse(BaseModel):
     """Response body for POST /api/closet/matching-items"""
     items: List[ClothingItemResponse]
+    other_items: List[ClothingItemResponse] = Field(
+        default_factory=list,
+        description=(
+            "Items in the same category that did not clear the match threshold. "
+            "Lets the UI offer an escape hatch when no strict matches exist."
+        ),
+    )
     total_in_category: int = Field(..., description="Total items user has in this category")
 
 
@@ -182,6 +189,7 @@ async def get_closet(current_user: User = Depends(get_current_user)) -> ClosetRe
                                 "created_at": "2025-12-01T10:20:30Z",
                             }
                         ],
+                        "other_items": [],
                         "total_in_category": 5,
                     }
                 }
@@ -239,17 +247,19 @@ async def get_matching_items(
             if item.category.l1 == request.category_l1
         )
         
-        # Filter and rank
-        matching_items = filter_and_rank_items(
+        # Filter and rank — split into strict matches and "other in category"
+        # so the UI can offer an escape hatch when nothing clears the threshold.
+        matching_items, other_items = rank_items_in_category(
             items=all_items,
             category_l1=request.category_l1,
             recommended_colors=request.recommended_colors,
             formality_range=request.formality_range,
             limit=request.limit,
         )
-        
+
         return MatchingItemsResponse(
             items=matching_items,
+            other_items=other_items,
             total_in_category=total_in_category,
         )
 

--- a/backend/app/services/matching.py
+++ b/backend/app/services/matching.py
@@ -72,6 +72,22 @@ def score_item_match(
     return score
 
 
+def _score_category_items(
+    items: List[ClothingItemResponse],
+    category_l1: str,
+    recommended_colors: List[RecommendedColor],
+    formality_range: FormalityRange,
+) -> List[Tuple[ClothingItemResponse, float]]:
+    """Filter items to the target category and return (item, score) pairs sorted by score desc."""
+    scored = [
+        (item, score_item_match(item, recommended_colors, formality_range))
+        for item in items
+        if item.category.l1 == category_l1
+    ]
+    scored.sort(key=lambda pair: pair[1], reverse=True)
+    return scored
+
+
 def filter_and_rank_items(
     items: List[ClothingItemResponse],
     category_l1: str,
@@ -80,35 +96,26 @@ def filter_and_rank_items(
     limit: int = 5,
     min_score: float = 40.0,
 ) -> List[ClothingItemResponse]:
+    """Return items in the category whose score >= min_score, sorted best-first."""
+    scored = _score_category_items(items, category_l1, recommended_colors, formality_range)
+    return [item for item, score in scored if score >= min_score][:limit]
+
+
+def rank_items_in_category(
+    items: List[ClothingItemResponse],
+    category_l1: str,
+    recommended_colors: List[RecommendedColor],
+    formality_range: FormalityRange,
+    limit: int = 5,
+    min_score: float = 40.0,
+) -> Tuple[List[ClothingItemResponse], List[ClothingItemResponse]]:
+    """Partition category items into (matches, others) by min_score.
+
+    Both lists are sorted best-first and capped at `limit`. Lets callers offer
+    an escape hatch when no items clear the threshold but the user still has
+    things in this category.
     """
-    Filter items by category and rank by match score.
-    
-    Args:
-        items: All user's closet items
-        category_l1: Category to filter by (e.g., "Bottoms")
-        recommended_colors: List of recommended colors
-        formality_range: Acceptable formality range
-        limit: Maximum items to return
-        min_score: Minimum match score to include
-    
-    Returns:
-        List of matching items sorted by score (best first)
-    """
-    # Filter by category
-    category_items = [
-        item for item in items 
-        if item.category.l1 == category_l1
-    ]
-    
-    # Score and filter
-    scored_items = []
-    for item in category_items:
-        score = score_item_match(item, recommended_colors, formality_range)
-        if score >= min_score:
-            scored_items.append((item, score))
-    
-    # Sort by score descending
-    scored_items.sort(key=lambda x: x[1], reverse=True)
-    
-    # Return top N items
-    return [item for item, score in scored_items[:limit]]
+    scored = _score_category_items(items, category_l1, recommended_colors, formality_range)
+    matches = [item for item, score in scored if score >= min_score][:limit]
+    others = [item for item, score in scored if score < min_score][:limit]
+    return matches, others

--- a/backend/tests/unit/test_matching.py
+++ b/backend/tests/unit/test_matching.py
@@ -8,6 +8,7 @@ from app.services.matching import (
     is_color_similar,
     score_item_match,
     filter_and_rank_items,
+    rank_items_in_category,
 )
 from app.models.schemas import (
     ClothingItemResponse,
@@ -361,8 +362,8 @@ class TestFilterAndRankItems:
         assert results == []
     
     def test_empty_items_list(
-        self, 
-        sample_recommended_colors, 
+        self,
+        sample_recommended_colors,
         sample_formality_range
     ):
         """Should handle empty items list gracefully."""
@@ -372,5 +373,103 @@ class TestFilterAndRankItems:
             recommended_colors=sample_recommended_colors,
             formality_range=sample_formality_range,
         )
-        
+
         assert results == []
+
+
+# =============================================================================
+# TESTS: rank_items_in_category (matches + others split)
+# =============================================================================
+
+class TestRankItemsInCategory:
+    def test_splits_above_and_below_threshold(
+        self,
+        sample_closet_items,
+        sample_recommended_colors,
+        sample_formality_range,
+    ):
+        """Items in the category split by min_score into (matches, others)."""
+        matches, others = rank_items_in_category(
+            sample_closet_items,
+            category_l1="Bottoms",
+            recommended_colors=sample_recommended_colors,
+            formality_range=sample_formality_range,
+            min_score=40.0,
+        )
+        all_in_category = matches + others
+        assert all(item.category.l1 == "Bottoms" for item in all_in_category)
+        # No item appears in both lists
+        match_ids = {item.id for item in matches}
+        other_ids = {item.id for item in others}
+        assert match_ids & other_ids == set()
+
+    def test_others_ranked_descending(
+        self,
+        sample_closet_items,
+        sample_recommended_colors,
+        sample_formality_range,
+    ):
+        """Below-threshold items still come back ranked best-first."""
+        # Use a very high min_score so several items land in 'others'.
+        _, others = rank_items_in_category(
+            sample_closet_items,
+            category_l1="Bottoms",
+            recommended_colors=sample_recommended_colors,
+            formality_range=sample_formality_range,
+            min_score=95.0,
+        )
+        if len(others) >= 2:
+            scores = [
+                score_item_match(item, sample_recommended_colors, sample_formality_range)
+                for item in others
+            ]
+            assert scores == sorted(scores, reverse=True)
+
+    def test_others_empty_when_all_match(
+        self,
+        sample_closet_items,
+        sample_recommended_colors,
+        sample_formality_range,
+    ):
+        """With min_score=0, every category item is a match and others is empty."""
+        matches, others = rank_items_in_category(
+            sample_closet_items,
+            category_l1="Bottoms",
+            recommended_colors=sample_recommended_colors,
+            formality_range=sample_formality_range,
+            min_score=0,
+        )
+        assert others == []
+        assert len(matches) > 0
+
+    def test_respects_limit_for_both_lists(
+        self,
+        sample_closet_items,
+        sample_recommended_colors,
+        sample_formality_range,
+    ):
+        matches, others = rank_items_in_category(
+            sample_closet_items,
+            category_l1="Bottoms",
+            recommended_colors=sample_recommended_colors,
+            formality_range=sample_formality_range,
+            limit=1,
+            min_score=50.0,
+        )
+        assert len(matches) <= 1
+        assert len(others) <= 1
+
+    def test_empty_category_returns_two_empty_lists(
+        self,
+        sample_closet_items,
+        sample_recommended_colors,
+        sample_formality_range,
+    ):
+        matches, others = rank_items_in_category(
+            sample_closet_items,
+            category_l1="Accessories",
+            recommended_colors=sample_recommended_colors,
+            formality_range=sample_formality_range,
+        )
+        assert matches == []
+        assert others == []

--- a/frontend/src/app/style/components/shared/SuggestionPanel.tsx
+++ b/frontend/src/app/style/components/shared/SuggestionPanel.tsx
@@ -19,6 +19,63 @@ interface SuggestionPanelProps {
   onQuickAdd?: (item: ClothingItemResponse) => void
 }
 
+function ClosetItemList({
+  items,
+  onQuickAdd,
+}: {
+  items: ClothingItemResponse[]
+  onQuickAdd?: (item: ClothingItemResponse) => void
+}) {
+  return (
+    <ul className="flex flex-col gap-2 max-h-[280px] overflow-y-auto pr-1">
+      {items.map((item) => (
+        <li key={item.id}>
+          <button
+            type="button"
+            onClick={() => onQuickAdd?.(item)}
+            className="group w-full flex items-center gap-3 px-3 py-2 border border-ink bg-paper hover:bg-paper-3 transition-colors text-left"
+          >
+            <div className="w-10 h-12 bg-paper-2 border border-ink shrink-0 overflow-hidden">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={item.image_url}
+                alt={item.category.l2}
+                className="w-full h-full object-cover"
+              />
+            </div>
+            <div className="flex-1 min-w-0">
+              <p className="font-display text-[14px] leading-none truncate">
+                {item.category.l2}
+              </p>
+              <div className="flex items-center gap-2 mt-1">
+                <i
+                  className="w-2 h-2 border border-ink"
+                  style={{ backgroundColor: item.color.hex }}
+                  aria-hidden="true"
+                />
+                <span className="font-mono text-[9px] uppercase tracking-[0.08em] text-ink-3 truncate">
+                  {item.color.name} ·{' '}
+                  {
+                    FORMALITY_LEVELS[
+                      item.formality as keyof typeof FORMALITY_LEVELS
+                    ]
+                  }
+                </span>
+              </div>
+            </div>
+            <span
+              className="font-mono text-[10px] uppercase tracking-[0.1em] text-ink-3 group-hover:text-ink shrink-0"
+              aria-hidden="true"
+            >
+              ＋
+            </span>
+          </button>
+        </li>
+      ))}
+    </ul>
+  )
+}
+
 export default function SuggestionPanel({
   recommendation,
   categoryL1,
@@ -28,6 +85,7 @@ export default function SuggestionPanel({
 }: SuggestionPanelProps) {
   const { session } = useAuth()
   const [matchingItems, setMatchingItems] = useState<ClothingItemResponse[]>([])
+  const [otherItems, setOtherItems] = useState<ClothingItemResponse[]>([])
   const [totalInCategory, setTotalInCategory] = useState(0)
   const [isLoadingMatches, setIsLoadingMatches] = useState(false)
   const [matchError, setMatchError] = useState<string | null>(null)
@@ -36,6 +94,7 @@ export default function SuggestionPanel({
     async function fetchMatches() {
       if (!recommendation || !session?.access_token) {
         setMatchingItems([])
+        setOtherItems([])
         return
       }
       setIsLoadingMatches(true)
@@ -51,11 +110,13 @@ export default function SuggestionPanel({
           session.access_token,
         )
         setMatchingItems(response.items)
+        setOtherItems(response.other_items)
         setTotalInCategory(response.total_in_category)
       } catch (err) {
         console.error('Failed to fetch matching items:', err)
         setMatchError('Could not load closet items.')
         setMatchingItems([])
+        setOtherItems([])
       } finally {
         setIsLoadingMatches(false)
       }
@@ -108,52 +169,15 @@ export default function SuggestionPanel({
                 {matchError}
               </p>
             ) : matchingItems.length > 0 ? (
-              <ul className="flex flex-col gap-2 max-h-[280px] overflow-y-auto pr-1">
-                {matchingItems.map((item) => (
-                  <li key={item.id}>
-                    <button
-                      type="button"
-                      onClick={() => onQuickAdd?.(item)}
-                      className="group w-full flex items-center gap-3 px-3 py-2 border border-ink bg-paper hover:bg-paper-3 transition-colors text-left"
-                    >
-                      <div className="w-10 h-12 bg-paper-2 border border-ink shrink-0 overflow-hidden">
-                        {/* eslint-disable-next-line @next/next/no-img-element */}
-                        <img
-                          src={item.image_url}
-                          alt={item.category.l2}
-                          className="w-full h-full object-cover"
-                        />
-                      </div>
-                      <div className="flex-1 min-w-0">
-                        <p className="font-display text-[14px] leading-none truncate">
-                          {item.category.l2}
-                        </p>
-                        <div className="flex items-center gap-2 mt-1">
-                          <i
-                            className="w-2 h-2 border border-ink"
-                            style={{ backgroundColor: item.color.hex }}
-                            aria-hidden="true"
-                          />
-                          <span className="font-mono text-[9px] uppercase tracking-[0.08em] text-ink-3 truncate">
-                            {item.color.name} ·{' '}
-                            {
-                              FORMALITY_LEVELS[
-                                item.formality as keyof typeof FORMALITY_LEVELS
-                              ]
-                            }
-                          </span>
-                        </div>
-                      </div>
-                      <span
-                        className="font-mono text-[10px] uppercase tracking-[0.1em] text-ink-3 group-hover:text-ink shrink-0"
-                        aria-hidden="true"
-                      >
-                        ＋
-                      </span>
-                    </button>
-                  </li>
-                ))}
-              </ul>
+              <ClosetItemList items={matchingItems} onQuickAdd={onQuickAdd} />
+            ) : otherItems.length > 0 ? (
+              <>
+                <p className="font-display italic text-[14px] text-ink-2 leading-snug mb-3">
+                  Nothing matches these recommendations exactly. Here&apos;s
+                  what else you have:
+                </p>
+                <ClosetItemList items={otherItems} onQuickAdd={onQuickAdd} />
+              </>
             ) : totalInCategory > 0 ? (
               <p className="font-display italic text-[14px] text-ink-2 leading-tight">
                 No matches in your closet. You have {totalInCategory}{' '}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -248,6 +248,7 @@ export interface MatchingItemsRequest {
 
 export interface MatchingItemsResponse {
   items: ClothingItemResponse[]
+  other_items: ClothingItemResponse[]
   total_in_category: number
 }
 


### PR DESCRIPTION
## Summary

Closes the dead-end UX where the suggestion panel would tell users *"you have 5 bottoms but none meet the recommendations"* with no way forward.

**Backend** (`services/matching.py`, `routers/closet.py`)
- New `rank_items_in_category(...) → (matches, others)` that splits category items by `min_score`. Both lists are ranked best-first and capped at `limit`.
- `filter_and_rank_items` preserved as a thin wrapper; both share a `_score_category_items` helper.
- `MatchingItemsResponse` gains `other_items: list[ClothingItemResponse]`.

**Frontend** (`SuggestionPanel.tsx`, `lib/api.ts`)
- When matches is empty but `other_items` has content: render the user's other items in that category under a short note ("Nothing matches these recommendations exactly. Here's what else you have:").
- Extract `ClosetItemList` helper so the match list and fallback list share rendering.

Behavior order in the panel:
1. Loading → "Searching your closet…"
2. Matches found → render matches (unchanged)
3. **No matches, but other items exist → render those (new escape hatch)**
4. No items in category at all → "Upload one below" (unchanged)