### PR TITLE
fix(validation): consistency + UX pass on validation engine

### DIFF
--- a/backend/app/services/compatibility.py
+++ b/backend/app/services/compatibility.py
@@ -58,8 +58,13 @@ from app.services.color_harmony import check_color_compatibility, generate_recom
 # ==============================================================================
 
 def _formality_label(f: float) -> str:
-    """Map a float formality to its labelled level (clamped to 1-5)."""
-    return FORMALITY_LEVELS[max(1, min(5, round(f)))]
+    """Map a float formality to its labelled level (clamped to 1-5).
+
+    Uses half-up rounding (int(f + 0.5)) rather than Python's built-in
+    banker's rounding so 2.5 → 3 (not 2) and 3.5 → 4 (not 4-by-banker's),
+    keeping the mapping symmetric and user-predictable.
+    """
+    return FORMALITY_LEVELS[max(1, min(5, int(f + 0.5)))]
 
 
 def check_formality_compatibility(formality1: float, formality2: float) -> tuple[str, str | None]:
@@ -293,7 +298,12 @@ def validate_item(
             pairing_warnings.append(msg)
     
     warnings.extend(pairing_warnings)
-    
+
+    # Two outfit pieces sharing the same l2 (e.g. multiple "Watches" under
+    # MAX_ACCESSORIES=3) would produce identical warning strings. Dedup before
+    # returning so the user sees each issue once.
+    warnings = list(dict.fromkeys(warnings))
+
     return ValidateItemResponse(
         color_status=color_status,
         formality_status=formality_status,

--- a/backend/app/services/compatibility.py
+++ b/backend/app/services/compatibility.py
@@ -48,6 +48,7 @@ from app.utils.constants import (
     MAX_OUTFIT_ITEMS,
     MAX_ACCESSORIES,
     MAX_OUTERWEAR,
+    FORMALITY_LEVELS,
 )
 from app.services.color_harmony import check_color_compatibility, generate_recommended_colors
 
@@ -56,29 +57,31 @@ from app.services.color_harmony import check_color_compatibility, generate_recom
 # FORMALITY CHECKING
 # ==============================================================================
 
+def _formality_label(f: float) -> str:
+    """Map a float formality to its labelled level (clamped to 1-5)."""
+    return FORMALITY_LEVELS[max(1, min(5, round(f)))]
+
+
 def check_formality_compatibility(formality1: float, formality2: float) -> tuple[str, str | None]:
     """Check formality compatibility between two items.
-    
+
     Logic:
-    - Calculate absolute distance between formality levels
-    - Distance <= 1: return ("ok", None)
-    - Distance <= 2: return ("warning", "Formality gap is 2 levels")
-    - Distance >= 3: return ("mismatch", "Formality mismatch: X levels apart")
-    
-    Returns:
-        tuple: (status, warning_message)
+    - Distance <= 1: ok
+    - Distance <= 2: warning
+    - Distance >= 3: mismatch
 
-    FIXED: method signatures from int to float
+    Warning text uses FORMALITY_LEVELS labels (e.g. "Smart Casual") rather
+    than raw float values, so the internal 1-5 scale doesn't leak into UI copy.
     """
-
     distance = abs(formality1 - formality2)
-    
+    label1 = _formality_label(formality1)
+    label2 = _formality_label(formality2)
+
     if distance <= 1.0:
         return ("ok", None)
-    elif distance <= 2.0:
-        return ("warning", f"Formality gap is 2 levels ({formality1} vs {formality2})")
-    else:  # distance >= 3.0
-        return ("mismatch", f"Formality mismatch: {distance:.1f} levels apart ({formality1} vs {formality2})")
+    if distance <= 2.0:
+        return ("warning", f"Formality gap: {label1} vs {label2}")
+    return ("mismatch", f"Formality mismatch: {label1} vs {label2}")
 
 
 # ==============================================================================
@@ -438,25 +441,21 @@ def calculate_cohesion_score(items: list[ClothingItemBase], base_item: ClothingI
 
 def get_verdict(score: int, is_complete: bool, warnings: list[str]) -> str:
     """Generate a human-readable verdict for the outfit.
-    
-    Logic:
-    - If not complete: "Incomplete outfit - missing required items"
-    - Score >= 85: "Excellent cohesive look!"
-    - Score >= 70: "Good outfit with minor style considerations"
-    - Score >= 50: "Decent outfit, but some elements may clash"
-    - Score < 50: "Consider revising - multiple style conflicts"
+
+    Verdict tiers are gated by both the cohesion score AND the presence of
+    warnings. An "Excellent" verdict implies a clean look — outfits carrying
+    any warning are capped at "Good" regardless of score.
     """
     if not is_complete:
         return "Incomplete outfit - missing required items"
-    
-    if score >= 85:
+
+    if score >= 85 and not warnings:
         return "Excellent cohesive look!"
-    elif score >= 70:
+    if score >= 70:
         return "Good outfit with minor style considerations"
-    elif score >= 50:
+    if score >= 50:
         return "Decent outfit, but some elements may clash"
-    else:
-        return "Consider revising - multiple style conflicts"
+    return "Consider revising - multiple style conflicts"
 
 
 # ==============================================================================
@@ -539,9 +538,15 @@ def validate_outfit(
     if len(aesthetic_sets) >= 2 and not set.intersection(*aesthetic_sets):
         warnings.append("No shared aesthetic tags across the outfit")
 
+    # Dedupe — pair-wise checks can produce the same warning string from
+    # multiple distinct pairs (e.g. three items at formality 1,1,5 surfaces
+    # the same Casual-vs-Black-Tie mismatch twice). Preserve first-seen order.
+    seen: set[str] = set()
+    warnings = [w for w in warnings if not (w in seen or seen.add(w))]
+
     # 6. Build color strip
     color_strip = [item.color.hex for item in full_outfit]
-    
+
     # 7. Generate verdict
     verdict = get_verdict(cohesion_score, is_complete, warnings)
     

--- a/backend/app/services/compatibility.py
+++ b/backend/app/services/compatibility.py
@@ -5,32 +5,35 @@ This module implements the core business logic for determining if clothing items
 work together. It evaluates compatibility across four distinct dimensions and
 aggregates them into cohesion scores and verdicts.
 
-
-
 **Key Responsibilities:**
 
 1.  **Multi-Dimensional Compatibility Checks:**
-    * **Formality:** Calculates numeric distance between items (1-5 scale).
-        * *Rule:* Gap > 1 level triggers a warning; Gap > 2 is a mismatch.
-    * **Aesthetics:** Checks for intersection of style tags (e.g., "boho", "streetwear").
-    * **Category Rules:** Enforces structural pairings, specifically identifying valid
-        Shoe-to-Bottom combinations.
+    * **Formality:** Numeric distance on the 1-5 scale. distance ≤ 1 = ok;
+      ≤ 2 = warning; > 2 = mismatch. Warning copy uses FORMALITY_LEVELS labels
+      rather than raw float values.
+    * **Aesthetics:** ≥1 shared tag = cohesive (single-item validator and outfit
+      scorer share this predicate).
+    * **Category Rules:** Shoe-to-Bottom pairings via SHOE_BOTTOM_PAIRINGS;
+      unknown shoe types stay silent rather than confidently warning.
     * **Color Harmony:** (Imported) Validates hue/saturation relationships.
 
 2.  **Validation Workflows:**
     * **Item Validation (`validate_item`):** Checks a single candidate item against
-        a base item and the current outfit draft.
+      a base item and the current outfit draft.
     * **Outfit Validation (`validate_outfit`):** Audits a complete look for
-        composition (missing required categories) and overall cohesion.
+      composition (missing required categories, per-category caps, duplicate
+      singletons) and overall cohesion.
 
 3.  **Scoring System (`calculate_cohesion_score`):**
-    * Uses a **penalty-based algorithm** starting at 100 points.
-    * Deducts points for color clashes (-30), formality gaps (-40), and lack of
-        shared aesthetic tags (-30).
+    Penalty-based, starts at 100. Caps:
+      * Color clashes: up to -30 (scaled by count of incompatible pairs)
+      * Formality range: up to -40 (with a 0.5-level dead-zone for float drift)
+      * Aesthetics: -30 when zero shared tags, else 0
+      * Over-max items: up to -20 (5 per extra item beyond MAX_OUTFIT_ITEMS)
 
 4.  **Recommendation Logic:**
-    * Generates targeted suggestions for missing categories based on the base item's
-        color palette and formality level.
+    * Generates targeted suggestions for missing categories based on the base
+      item's color palette and formality level.
 """
 
 from app.models.schemas import (
@@ -544,15 +547,17 @@ def validate_outfit(
                 warnings.append(msg)
 
     # Outfit-level aesthetic check (not pair-wise to avoid duplicate noise).
+    # Guard `>= 2`: a single tagged item can't disagree with itself, so there's
+    # nothing meaningful to warn about until two tagged items exist.
     aesthetic_sets = [set(item.aesthetics) for item in full_outfit if item.aesthetics]
     if len(aesthetic_sets) >= 2 and not set.intersection(*aesthetic_sets):
         warnings.append("No shared aesthetic tags across the outfit")
 
     # Dedupe — pair-wise checks can produce the same warning string from
     # multiple distinct pairs (e.g. three items at formality 1,1,5 surfaces
-    # the same Casual-vs-Black-Tie mismatch twice). Preserve first-seen order.
-    seen: set[str] = set()
-    warnings = [w for w in warnings if not (w in seen or seen.add(w))]
+    # the same Casual-vs-Black-Tie mismatch twice). dict.fromkeys preserves
+    # first-seen order on Python 3.7+.
+    warnings = list(dict.fromkeys(warnings))
 
     # 6. Build color strip
     color_strip = [item.color.hex for item in full_outfit]

--- a/backend/app/services/compatibility.py
+++ b/backend/app/services/compatibility.py
@@ -46,6 +46,8 @@ from app.utils.constants import (
     REQUIRED_CATEGORIES_STANDARD,
     REQUIRED_CATEGORIES_FULLBODY,
     MAX_OUTFIT_ITEMS,
+    MAX_ACCESSORIES,
+    MAX_OUTERWEAR,
 )
 from app.services.color_harmony import check_color_compatibility, generate_recommended_colors
 
@@ -422,7 +424,13 @@ def calculate_cohesion_score(items: list[ClothingItemBase], base_item: ClothingI
         aesthetic_penalty = 0  # Single or zero items with tags — nothing to disagree about.
 
     score -= aesthetic_penalty
-    
+
+    # Over-max-items penalty: previously this only emitted a warning string
+    # in validate_outfit, but a 10-item outfit could still score 100. Five
+    # points per extra item, capped at 20.
+    if total_items > MAX_OUTFIT_ITEMS:
+        score -= min((total_items - MAX_OUTFIT_ITEMS) * 5, 20)
+
     # Ensure score is between 0-100
     return max(0, min(100, int(score)))
 
@@ -477,13 +485,30 @@ def validate_outfit(
     # 2. Check composition
     is_complete, missing_categories = check_outfit_composition(full_outfit)
     
-    # 3. Check total items
+    # 3. Check total items and per-category caps
     warnings = []
     if len(full_outfit) > MAX_OUTFIT_ITEMS:
         warnings.append(f"Outfit has {len(full_outfit)} items (max: {MAX_OUTFIT_ITEMS})")
-    
+
     if missing_categories:
         warnings.append(f"Missing required categories: {', '.join(missing_categories)}")
+
+    # Per-category caps and singleton-category checks. MAX_ACCESSORIES and
+    # MAX_OUTERWEAR were unused constants before this; the singleton categories
+    # (Tops/Bottoms/Shoes/Full Body) shouldn't appear more than once.
+    items_by_l1 = get_categories_in_outfit(full_outfit)
+    if len(items_by_l1.get("Accessories", [])) > MAX_ACCESSORIES:
+        warnings.append(
+            f"Too many accessories ({len(items_by_l1['Accessories'])} — max: {MAX_ACCESSORIES})"
+        )
+    if len(items_by_l1.get("Outerwear", [])) > MAX_OUTERWEAR:
+        warnings.append(
+            f"Too many outerwear pieces ({len(items_by_l1['Outerwear'])} — max: {MAX_OUTERWEAR})"
+        )
+    for l1 in ("Tops", "Bottoms", "Shoes", "Full Body"):
+        count = len(items_by_l1.get(l1, []))
+        if count > 1:
+            warnings.append(f"Multiple {l1} in outfit ({count})")
     
     # 4. Calculate cohesion score
     cohesion_score = calculate_cohesion_score(items, base_item)

--- a/backend/app/services/compatibility.py
+++ b/backend/app/services/compatibility.py
@@ -405,11 +405,12 @@ def calculate_cohesion_score(items: list[ClothingItemBase], base_item: ClothingI
     color_penalty = min(incompatible_pairs * 10, 30)
     score -= color_penalty
     
-    # Formality penalty (up to -40 points)
-    # VALIDATION FIX: Explicitly handle float formality values
+    # Formality penalty (up to -40 points). A 0.5-level dead-zone absorbs
+    # small float drift (3.0 vs 3.1) that's visually identical to the user;
+    # everything above that scales linearly.
     formality_levels = [float(item.formality) for item in all_items]
     formality_range = max(formality_levels) - min(formality_levels)
-    formality_penalty = min(formality_range * 10, 40)
+    formality_penalty = min(max(0.0, formality_range - 0.5) * 10, 40)
     score -= formality_penalty
     
     # Aesthetic penalty (up to -30 points). Threshold matches

--- a/backend/app/services/compatibility.py
+++ b/backend/app/services/compatibility.py
@@ -250,12 +250,25 @@ def validate_item(
     
     warnings.extend(formality_warnings)
     
-    # 3. Aesthetic compatibility (only vs base_item)
-    aesthetic_status, aesthetic_msg = check_aesthetic_compatibility(
-        new_item.aesthetics, base_item.aesthetics
-    )
-    if aesthetic_msg:
-        warnings.append(aesthetic_msg)
+    # 3. Aesthetic compatibility — check vs base_item AND each current_outfit
+    # item so a drifted outfit isn't masked by a matching base.
+    aesthetic_status = "cohesive"
+    aesthetic_warnings = []
+
+    status, _ = check_aesthetic_compatibility(new_item.aesthetics, base_item.aesthetics)
+    if status == "warning":
+        aesthetic_status = "warning"
+        aesthetic_warnings.append("No shared aesthetic tags with base item")
+
+    for item in current_outfit:
+        status, _ = check_aesthetic_compatibility(new_item.aesthetics, item.aesthetics)
+        if status == "warning":
+            aesthetic_status = "warning"
+            aesthetic_warnings.append(
+                f"No shared aesthetic tags with {item.category.l2}"
+            )
+
+    warnings.extend(aesthetic_warnings)
     
     # 4. Category pairing checks
     pairing_status = "ok"
@@ -397,22 +410,17 @@ def calculate_cohesion_score(items: list[ClothingItemBase], base_item: ClothingI
     formality_penalty = min(formality_range * 10, 40)
     score -= formality_penalty
     
-    # Aesthetic penalty (up to -30 points)
+    # Aesthetic penalty (up to -30 points). Threshold matches
+    # check_aesthetic_compatibility: ≥1 shared tag is cohesive (no penalty);
+    # 0 shared tags is penalized. The previous "1 shared = -10" middle tier
+    # contradicted what the single-item validator was telling users.
     all_aesthetics = [set(item.aesthetics) for item in all_items if item.aesthetics]
-    
-    if all_aesthetics:
-        # Find common tags across ALL items
-        common_tags = set.intersection(*all_aesthetics) if all_aesthetics else set()
-        
-        if len(common_tags) == 0:
-            aesthetic_penalty = 30
-        elif len(common_tags) == 1:
-            aesthetic_penalty = 10
-        else:  # 2+ common tags
-            aesthetic_penalty = 0
+    if len(all_aesthetics) >= 2:
+        common_tags = set.intersection(*all_aesthetics)
+        aesthetic_penalty = 0 if common_tags else 30
     else:
-        aesthetic_penalty = 0  # No aesthetics = no penalty
-    
+        aesthetic_penalty = 0  # Single or zero items with tags — nothing to disagree about.
+
     score -= aesthetic_penalty
     
     # Ensure score is between 0-100
@@ -499,7 +507,12 @@ def validate_outfit(
             status, msg = check_category_pairing(item1, item2)
             if status == "warning":
                 warnings.append(msg)
-    
+
+    # Outfit-level aesthetic check (not pair-wise to avoid duplicate noise).
+    aesthetic_sets = [set(item.aesthetics) for item in full_outfit if item.aesthetics]
+    if len(aesthetic_sets) >= 2 and not set.intersection(*aesthetic_sets):
+        warnings.append("No shared aesthetic tags across the outfit")
+
     # 6. Build color strip
     color_strip = [item.color.hex for item in full_outfit]
     

--- a/backend/tests/unit/test_compatibility.py
+++ b/backend/tests/unit/test_compatibility.py
@@ -76,12 +76,16 @@ def test_check_formality_compatibility(formality1: float, formality2: float, exp
     """Test formality compatibility with float values (validation fix)."""
     status, msg = compatibility.check_formality_compatibility(formality1, formality2)
     assert status == expected_status
-    
+
     if expected_status == "ok":
         assert msg is None
     else:
         assert msg is not None
-        assert str(formality1) in msg or str(formality2) in msg
+        # Warning text uses labelled levels (e.g. "Casual", "Smart Casual"),
+        # not the raw float values.
+        label1 = compatibility._formality_label(formality1)
+        label2 = compatibility._formality_label(formality2)
+        assert label1 in msg or label2 in msg
 
 
 def test_check_formality_compatibility_boundary_cases():
@@ -715,6 +719,45 @@ def test_cohesion_score_penalized_when_over_max_items():
     ]
     score = compatibility.calculate_cohesion_score(items, base_item)
     assert score < 100
+
+
+def test_validate_outfit_dedupes_pairwise_warnings():
+    """Three items at formality 1, 1, 5 — the 1-vs-5 mismatch arises from
+    two distinct pairs but shouldn't appear twice in warnings."""
+    base_item = _make_item("Tops", "T-Shirts", formality=1.0, aesthetics=["Minimalist"])
+    items = [
+        _make_item("Bottoms", "Jeans", formality=1.0, aesthetics=["Minimalist"]),
+        _make_item("Shoes", "Sneakers", formality=5.0, aesthetics=["Minimalist"]),
+    ]
+    response = compatibility.validate_outfit(items, base_item)
+    seen = set()
+    for w in response.warnings:
+        assert w not in seen, f"duplicate warning: {w!r}"
+        seen.add(w)
+
+
+def test_get_verdict_respects_warnings_arg():
+    """Even with a high score, an outfit carrying warnings shouldn't read
+    'Excellent'. The previously-unused warnings parameter is now respected."""
+    assert "Excellent" not in compatibility.get_verdict(
+        90, is_complete=True, warnings=["Color may clash"]
+    )
+    # No warnings, same score → "Excellent" still allowed.
+    assert "Excellent" in compatibility.get_verdict(90, is_complete=True, warnings=[])
+
+
+def test_formality_warning_text_uses_labels_not_floats():
+    """Warning copy must use the labelled formality level (e.g.
+    'Smart Casual') rather than leak the internal float ('2.0')."""
+    base_item = _make_item("Tops", "T-Shirts", formality=2.0)
+    new_item = _make_item("Bottoms", "Jeans", formality=5.0)
+    response = compatibility.validate_item(new_item, base_item, [])
+    formality_warnings = [w for w in response.warnings if "Formality" in w]
+    assert formality_warnings, "expected a formality warning for a 2.0 vs 5.0 gap"
+    for w in formality_warnings:
+        # No bare floats like "2.0" or "5.0" — labels only.
+        assert "2.0" not in w
+        assert "5.0" not in w
 
 
 def test_validate_outfit_emits_aesthetic_warning_when_no_shared_tags():

--- a/backend/tests/unit/test_compatibility.py
+++ b/backend/tests/unit/test_compatibility.py
@@ -12,7 +12,7 @@ from app.models.schemas import (
     ValidateOutfitResponse,
 )
 from app.services import compatibility
-from app.utils.constants import SHOE_BOTTOM_PAIRINGS, MAX_OUTFIT_ITEMS
+from app.utils.constants import SHOE_BOTTOM_PAIRINGS, MAX_OUTFIT_ITEMS, FORMALITY_LEVELS
 
 
 # ==============================================================================
@@ -82,10 +82,12 @@ def test_check_formality_compatibility(formality1: float, formality2: float, exp
     else:
         assert msg is not None
         # Warning text uses labelled levels (e.g. "Casual", "Smart Casual"),
-        # not the raw float values.
-        label1 = compatibility._formality_label(formality1)
-        label2 = compatibility._formality_label(formality2)
-        assert label1 in msg or label2 in msg
+        # not the raw float values. Computed from FORMALITY_LEVELS directly
+        # rather than via compatibility._formality_label so the test isn't
+        # coupled to a private helper.
+        def _expected_label(f: float) -> str:
+            return FORMALITY_LEVELS[max(1, min(5, int(f + 0.5)))]
+        assert _expected_label(formality1) in msg or _expected_label(formality2) in msg
 
 
 def test_check_formality_compatibility_boundary_cases():
@@ -696,16 +698,33 @@ def test_validate_outfit_warns_when_too_many_outerwear():
     assert any("outerwear" in w.lower() for w in response.warnings)
 
 
-def test_validate_outfit_warns_on_duplicate_singleton_category():
-    """Two pairs of Shoes in one outfit shouldn't pass silently."""
-    base_item = _make_item("Tops", "T-Shirts", aesthetics=["Minimalist"])
+@pytest.mark.parametrize(
+    "duplicate_l1, l2_pair",
+    [
+        ("Tops", ("T-Shirts", "Casual Shirts")),
+        ("Bottoms", ("Jeans", "Chinos")),
+        ("Shoes", ("Sneakers", "Boots")),
+        ("Full Body", ("Dresses", "Suits")),
+    ],
+)
+def test_validate_outfit_warns_on_duplicate_singleton_category(
+    duplicate_l1: str, l2_pair: tuple[str, str]
+):
+    """All four singleton L1s (Tops/Bottoms/Shoes/Full Body) must warn on dups."""
+    # Base in a different category so the duplicate is in the outfit items.
+    base_item = _make_item(
+        "Accessories" if duplicate_l1 != "Accessories" else "Tops",
+        "Watches",
+        aesthetics=["Minimalist"],
+    )
     items = [
-        _make_item("Bottoms", "Jeans", aesthetics=["Minimalist"]),
-        _make_item("Shoes", "Sneakers", aesthetics=["Minimalist"]),
-        _make_item("Shoes", "Boots", aesthetics=["Minimalist"]),
+        _make_item(duplicate_l1, l2_pair[0], aesthetics=["Minimalist"]),
+        _make_item(duplicate_l1, l2_pair[1], aesthetics=["Minimalist"]),
     ]
     response = compatibility.validate_outfit(items, base_item)
-    assert any("shoes" in w.lower() for w in response.warnings)
+    assert any(
+        duplicate_l1.lower() in w.lower() for w in response.warnings
+    ), f"expected a 'Multiple {duplicate_l1}' warning, got {response.warnings!r}"
 
 
 def test_cohesion_score_penalized_when_over_max_items():

--- a/backend/tests/unit/test_compatibility.py
+++ b/backend/tests/unit/test_compatibility.py
@@ -438,10 +438,27 @@ def test_calculate_cohesion_score_no_common_aesthetics():
         _make_item("Bottoms", "Jeans", formality=3.0, aesthetics=["Preppy"]),
         _make_item("Shoes", "Sneakers", formality=3.0, aesthetics=["Classic"]),
     ]
-    
+
     score = compatibility.calculate_cohesion_score(items, base_item)
     # Should have aesthetic penalty (-30)
     assert score <= 70
+
+
+def test_calculate_cohesion_score_aesthetic_threshold_matches_validator():
+    """Scoring and check_aesthetic_compatibility must agree: ≥1 shared tag is
+    cohesive and incurs no penalty. Previously the validator said 'cohesive'
+    while the scorer still deducted -10 for exactly 1 shared tag."""
+    base_item = _make_item(
+        "Tops", "T-Shirts", formality=3.0, aesthetics=["Minimalist", "Classic"]
+    )
+    items = [
+        _make_item(
+            "Bottoms", "Jeans", formality=3.0, aesthetics=["Minimalist", "Streetwear"]
+        ),  # only "Minimalist" shared
+    ]
+    score = compatibility.calculate_cohesion_score(items, base_item)
+    # 1 shared tag → no aesthetic penalty.
+    assert score == 100
 
 
 def test_calculate_cohesion_score_float_formality():
@@ -577,6 +594,24 @@ def test_validate_item_color_clash_warning_text_excludes_internal_label():
         assert "(none)" not in warning
 
 
+def test_validate_item_aesthetic_checks_current_outfit():
+    """Aesthetic check shouldn't be limited to base_item — if the current
+    outfit has drifted, a new item that mismatches an outfit piece must warn."""
+    base_item = _make_item(
+        "Tops", "T-Shirts", formality=3.0, aesthetics=["Minimalist"]
+    )
+    outfit_piece = _make_item(
+        "Bottoms", "Jeans", formality=3.0, aesthetics=["Streetwear"]
+    )
+    new_item = _make_item(
+        "Shoes", "Sneakers", formality=3.0, aesthetics=["Minimalist"]
+    )  # matches base but not outfit_piece
+    response = compatibility.validate_item(new_item, base_item, [outfit_piece])
+    assert response.aesthetic_status == "warning"
+    # The Jeans-specific mismatch should be visible in the warnings.
+    assert any("Jeans" in w for w in response.warnings)
+
+
 # ==============================================================================
 # FULL OUTFIT VALIDATION TESTS
 # ==============================================================================
@@ -612,6 +647,21 @@ def test_validate_outfit_incomplete():
     assert "Incomplete" in response.verdict
     assert len(response.warnings) > 0
     assert any("missing" in w.lower() for w in response.warnings)
+
+
+def test_validate_outfit_emits_aesthetic_warning_when_no_shared_tags():
+    """validate_outfit previously checked color/formality/pairing pair-wise
+    but never surfaced aesthetic warnings. An outfit with zero shared tags
+    across items must warn."""
+    base_item = _make_item(
+        "Tops", "T-Shirts", formality=3.0, aesthetics=["Streetwear"]
+    )
+    items = [
+        _make_item("Bottoms", "Jeans", formality=3.0, aesthetics=["Preppy"]),
+        _make_item("Shoes", "Sneakers", formality=3.0, aesthetics=["Classic"]),
+    ]
+    response = compatibility.validate_outfit(items, base_item)
+    assert any("aesthetic" in w.lower() for w in response.warnings)
 
 
 def test_validate_outfit_too_many_items():

--- a/backend/tests/unit/test_compatibility.py
+++ b/backend/tests/unit/test_compatibility.py
@@ -649,6 +649,59 @@ def test_validate_outfit_incomplete():
     assert any("missing" in w.lower() for w in response.warnings)
 
 
+def test_validate_outfit_warns_when_too_many_accessories():
+    """MAX_ACCESSORIES=3 is in constants.py but was previously unenforced."""
+    base_item = _make_item("Tops", "T-Shirts", aesthetics=["Minimalist"])
+    items = [
+        _make_item("Bottoms", "Jeans", aesthetics=["Minimalist"]),
+        _make_item("Shoes", "Sneakers", aesthetics=["Minimalist"]),
+        _make_item("Accessories", "Watches", aesthetics=["Minimalist"]),
+        _make_item("Accessories", "Belts", aesthetics=["Minimalist"]),
+        _make_item("Accessories", "Hats", aesthetics=["Minimalist"]),
+        _make_item("Accessories", "Bags", aesthetics=["Minimalist"]),  # 4th — over cap
+    ]
+    response = compatibility.validate_outfit(items, base_item)
+    assert any("accessor" in w.lower() for w in response.warnings)
+
+
+def test_validate_outfit_warns_when_too_many_outerwear():
+    """MAX_OUTERWEAR=1 is in constants.py but was previously unenforced."""
+    base_item = _make_item("Tops", "T-Shirts", aesthetics=["Minimalist"])
+    items = [
+        _make_item("Bottoms", "Jeans", aesthetics=["Minimalist"]),
+        _make_item("Shoes", "Sneakers", aesthetics=["Minimalist"]),
+        _make_item("Outerwear", "Jackets", aesthetics=["Minimalist"]),
+        _make_item("Outerwear", "Coats", aesthetics=["Minimalist"]),
+    ]
+    response = compatibility.validate_outfit(items, base_item)
+    assert any("outerwear" in w.lower() for w in response.warnings)
+
+
+def test_validate_outfit_warns_on_duplicate_singleton_category():
+    """Two pairs of Shoes in one outfit shouldn't pass silently."""
+    base_item = _make_item("Tops", "T-Shirts", aesthetics=["Minimalist"])
+    items = [
+        _make_item("Bottoms", "Jeans", aesthetics=["Minimalist"]),
+        _make_item("Shoes", "Sneakers", aesthetics=["Minimalist"]),
+        _make_item("Shoes", "Boots", aesthetics=["Minimalist"]),
+    ]
+    response = compatibility.validate_outfit(items, base_item)
+    assert any("shoes" in w.lower() for w in response.warnings)
+
+
+def test_cohesion_score_penalized_when_over_max_items():
+    """Over-max-items previously surfaced a warning but didn't move the score.
+    The score should reflect that the outfit is over budget."""
+    base_item = _make_item("Tops", "T-Shirts", aesthetics=["Minimalist"])
+    # 8 extra items, way over MAX_OUTFIT_ITEMS=6 (incl. base = 9 total).
+    items = [
+        _make_item("Accessories", f"X{i}", aesthetics=["Minimalist"])
+        for i in range(8)
+    ]
+    score = compatibility.calculate_cohesion_score(items, base_item)
+    assert score < 100
+
+
 def test_validate_outfit_emits_aesthetic_warning_when_no_shared_tags():
     """validate_outfit previously checked color/formality/pairing pair-wise
     but never surfaced aesthetic warnings. An outfit with zero shared tags

--- a/backend/tests/unit/test_compatibility.py
+++ b/backend/tests/unit/test_compatibility.py
@@ -425,10 +425,25 @@ def test_calculate_cohesion_score_formality_gap():
     items = [
         _make_item("Bottoms", "Jeans", formality=5.0),  # Large gap
     ]
-    
+
     score = compatibility.calculate_cohesion_score(items, base_item)
-    # Should be lower due to formality penalty (range = 4, penalty = min(40, 40) = 40)
-    assert score <= 60  # 100 - 40 = 60 (plus any other penalties)
+    # With a 0.5 formality dead-zone: range=4 → (4-0.5)*10 = 35 penalty.
+    assert score <= 65
+
+
+def test_calculate_cohesion_score_formality_deadzone_no_penalty():
+    """Float formality gaps within ±0.5 should not move the score. 3.0 vs 3.1
+    is visually identical to the user — penalizing it for -1 point is noise."""
+    base_item = _make_item(
+        "Tops", "T-Shirts", formality=3.0, aesthetics=["Minimalist"]
+    )
+    items = [
+        _make_item(
+            "Bottoms", "Jeans", formality=3.4, aesthetics=["Minimalist"]
+        ),
+    ]
+    score = compatibility.calculate_cohesion_score(items, base_item)
+    assert score == 100
 
 
 def test_calculate_cohesion_score_no_common_aesthetics():

--- a/frontend/src/app/style/components/AddItemPanel.tsx
+++ b/frontend/src/app/style/components/AddItemPanel.tsx
@@ -85,6 +85,7 @@ export default function AddItemPanel({
   const [showOptional, setShowOptional] = useState(false)
   const [isExtracting, setIsExtracting] = useState(false)
   const [isValidating, setIsValidating] = useState(false)
+  const [validationError, setValidationError] = useState<string | null>(null)
   const [pendingTryOnUrl, setPendingTryOnUrl] = useState<string | null>(null)
 
   const [magnifierPosition, setMagnifierPosition] = useState<{
@@ -489,6 +490,7 @@ export default function AddItemPanel({
       return
 
     setIsValidating(true)
+    setValidationError(null)
     try {
       const newItem = {
         image_url: addingItem.croppedImage.croppedUrl,
@@ -503,14 +505,16 @@ export default function AddItemPanel({
       setItemValidation(validation)
       setCurrentStep('validate')
     } catch (error) {
+      // Don't fake a successful validation response — surface the failure
+      // explicitly so the user can distinguish "compatible" from "we couldn't
+      // check".
       console.error('Validation failed', error)
-      setItemValidation({
-        color_status: 'ok',
-        formality_status: 'ok',
-        aesthetic_status: 'cohesive',
-        pairing_status: 'ok',
-        warnings: ['Validation service unavailable — proceeding with caution.'],
-      })
+      setItemValidation(null)
+      setValidationError(
+        error instanceof Error
+          ? error.message
+          : 'Could not reach the validation service.',
+      )
       setCurrentStep('validate')
     } finally {
       setIsValidating(false)
@@ -962,7 +966,47 @@ export default function AddItemPanel({
         )}
 
         {/* STEP 4 — VALIDATE */}
-        {currentStep === 'validate' && itemValidation && (
+        {currentStep === 'validate' && validationError && (
+          <div className="flex flex-col gap-6">
+            <div>
+              <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-accent mb-2">
+                Validation unavailable
+              </p>
+              <h3 className="font-display text-[32px] leading-tight tracking-[-0.015em]">
+                We couldn&apos;t check this <em className="italic text-ink-3">piece</em>.
+              </h3>
+              <p className="font-display italic text-[16px] text-ink-2 mt-2 max-w-[34ch]">
+                {validationError}
+              </p>
+            </div>
+            <div className="flex items-center justify-between gap-6 pt-3">
+              <button
+                type="button"
+                onClick={() => setCurrentStep('colors')}
+                className="font-mono text-[11px] uppercase tracking-[0.12em] pb-[2px] border-b border-transparent hover:border-ink transition-colors"
+              >
+                ← Back
+              </button>
+              <button
+                type="button"
+                onClick={handleConfirmAdd}
+                disabled={isAdding}
+                className={cn(
+                  'inline-flex items-center justify-between gap-6 px-[18px] py-[12px]',
+                  'border border-ink bg-paper text-ink',
+                  'font-mono text-[11px] uppercase tracking-[0.12em]',
+                  'transition-colors hover:bg-ink hover:text-paper',
+                  'disabled:opacity-40 disabled:cursor-not-allowed',
+                )}
+              >
+                <span>Add anyway</span>
+                <span aria-hidden="true">→</span>
+              </button>
+            </div>
+          </div>
+        )}
+
+        {currentStep === 'validate' && itemValidation && !validationError && (
           <div className="flex flex-col gap-6">
             <div>
               <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-ink-3 mb-2">

--- a/frontend/src/app/style/components/SummaryStep.tsx
+++ b/frontend/src/app/style/components/SummaryStep.tsx
@@ -196,7 +196,9 @@ export default function SummaryStep() {
           {(() => {
             // Use the validated color strip when available; otherwise fall
             // back to item colors directly so the palette still renders even
-            // if validation failed.
+            // if validation failed. Both sources should produce the same
+            // sequence under normal operation — the fallback only matters
+            // when the validation API was unreachable.
             const colorStrip =
               validation?.color_strip && validation.color_strip.length > 0
                 ? validation.color_strip

--- a/frontend/src/app/style/components/SummaryStep.tsx
+++ b/frontend/src/app/style/components/SummaryStep.tsx
@@ -25,6 +25,7 @@ export default function SummaryStep() {
   const [validation, setValidation] = useState<ValidateOutfitResponse | null>(
     null,
   )
+  const [validationError, setValidationError] = useState<string | null>(null)
   const [isValidating, setIsValidating] = useState(true)
   const [isSaving, setIsSaving] = useState(false)
   const [saveProgress, setSaveProgress] = useState<string>('')
@@ -52,17 +53,13 @@ export default function SummaryStep() {
         const result = await validateOutfit(allItems, baseItem)
         setValidation(result)
       } catch (error) {
-        setValidation({
-          is_complete: true,
-          cohesion_score: 0,
-          verdict: 'Validation unavailable.',
-          color_strip: allItems.map((item) => item.color.hex),
-          warnings: [
-            error instanceof Error
-              ? error.message
-              : 'Could not reach the validation service.',
-          ],
-        })
+        // Don't fake a score-of-0 response — distinguish "validation failed"
+        // from "outfit is bad". Leave validation null and surface the error.
+        setValidationError(
+          error instanceof Error
+            ? error.message
+            : 'Could not reach the validation service.',
+        )
       } finally {
         setIsValidating(false)
       }
@@ -196,27 +193,37 @@ export default function SummaryStep() {
             </div>
           </section>
 
-          {validation?.color_strip && validation.color_strip.length > 0 && (
-            <section>
-              <header className="grid grid-cols-[auto_1fr] gap-4 items-baseline pb-[14px] mb-5 border-b border-ink">
-                <span className="font-display text-[24px] leading-none tracking-[-0.015em]">
-                  Palette
-                </span>
-                <span className="h-px bg-ink" aria-hidden="true" />
-              </header>
-              <div className="flex h-12 border border-ink overflow-hidden">
-                {validation.color_strip.map((hex, i) => (
-                  <div
-                    key={`${hex}-${i}`}
-                    className="flex-1"
-                    style={{ backgroundColor: hex }}
-                    title={hex.toUpperCase()}
-                    aria-label={`Color ${i + 1}: ${hex.toUpperCase()}`}
-                  />
-                ))}
-              </div>
-            </section>
-          )}
+          {(() => {
+            // Use the validated color strip when available; otherwise fall
+            // back to item colors directly so the palette still renders even
+            // if validation failed.
+            const colorStrip =
+              validation?.color_strip && validation.color_strip.length > 0
+                ? validation.color_strip
+                : allItems.map((item) => item.color.hex)
+            if (colorStrip.length === 0) return null
+            return (
+              <section>
+                <header className="grid grid-cols-[auto_1fr] gap-4 items-baseline pb-[14px] mb-5 border-b border-ink">
+                  <span className="font-display text-[24px] leading-none tracking-[-0.015em]">
+                    Palette
+                  </span>
+                  <span className="h-px bg-ink" aria-hidden="true" />
+                </header>
+                <div className="flex h-12 border border-ink overflow-hidden">
+                  {colorStrip.map((hex, i) => (
+                    <div
+                      key={`${hex}-${i}`}
+                      className="flex-1"
+                      style={{ backgroundColor: hex }}
+                      title={hex.toUpperCase()}
+                      aria-label={`Color ${i + 1}: ${hex.toUpperCase()}`}
+                    />
+                  ))}
+                </div>
+              </section>
+            )
+          })()}
         </div>
 
         {/* Analysis + actions */}
@@ -232,6 +239,19 @@ export default function SummaryStep() {
             {isValidating ? (
               <div className="font-display italic text-[18px] text-ink-2">
                 Analyzing outfit…
+              </div>
+            ) : validationError ? (
+              <div className="flex flex-col gap-3">
+                <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-accent">
+                  Validation unavailable
+                </p>
+                <p className="font-display italic text-[18px] leading-[1.35] text-ink-2 max-w-[42ch]">
+                  {validationError}
+                </p>
+                <p className="font-display italic text-[14px] text-ink-3 max-w-[42ch]">
+                  You can still save or try this outfit on — we just
+                  couldn&apos;t check it this time.
+                </p>
               </div>
             ) : validation ? (
               <div className="flex flex-col gap-6">


### PR DESCRIPTION
## Summary

Second of two PRs from the validation engine audit. PR #46 was the correctness slice; this one closes consistency drift and UX dead-ends.

**Aesthetic consistency** (`compatibility.py`)
- Single-item validator and outfit scorer now use the same predicate: ≥1 shared tag is cohesive. Previously the validator said "cohesive" while the scorer still deducted -10 for exactly 1 shared tag.
- `validate_item` now checks aesthetics against `current_outfit` items, not just `base_item`. A drifted outfit was previously masked by a matching base.
- `validate_outfit` emits an aesthetic warning when no shared tags exist across items (previously color/formality/pairing warnings surfaced but aesthetics were silent).

**Outfit composition rigor**
- `MAX_ACCESSORIES` (3) and `MAX_OUTERWEAR` (1) — unused constants — now generate warnings when exceeded.
- Singleton-category duplicates (two Tops, two Shoes, etc.) warn.
- Over-max-items now affects cohesion score (5 points per extra item, capped at 20), not just emits a warning string.

**Penalty and copy polish**
- Formality penalty has a 0.5 dead-zone for float drift. 3.0 vs 3.1 no longer costs a point.
- Warning text uses `FORMALITY_LEVELS` labels ("Smart Casual") instead of leaking the internal float ("3.0").
- Pair-wise warnings deduped before reaching the response.
- `get_verdict` now respects its (previously unused) `warnings` arg — outfits with warnings can't read "Excellent".

**Frontend: surface validation errors explicitly** (`SummaryStep.tsx`, `AddItemPanel.tsx`)
- Both components previously caught API failures and synthesized a "successful" response — AddItemPanel set all four statuses to `ok`; SummaryStep set `cohesion_score` to 0. Users couldn't tell "outfit is fine" from "service is down" from "outfit scored 0".
- Now each holds a separate `validationError` string and renders a dedicated "Validation unavailable" notice with the error message + an "Add anyway"/save escape. Summary palette falls back to deriving the strip from items when validation didn't run.
