### PR TITLE
feat(tryon): cost & storage controls

### DIFF
--- a/backend/app/routers/tryon.py
+++ b/backend/app/routers/tryon.py
@@ -15,7 +15,11 @@ from app.models.schemas import (
     TryOnOutfitRequest,
 )
 from app.services.gemini import generate_tryon_single, generate_tryon_outfit
-from app.services.supabase import upload_generated_image, get_supabase_client
+from app.services.supabase import (
+    upload_generated_image,
+    upload_image,
+    get_supabase_client,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -138,6 +142,82 @@ async def upload_user_photo(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to upload photo",
+        )
+
+
+@router.post(
+    "/upload-item-image",
+    summary="Upload an item image for try-on",
+    description=(
+        "Uploads a clothing item image (typically a cropped blob from the build "
+        "flow before the item is saved to the closet) to the clothing-images "
+        "bucket. Returns a public URL the try-on endpoints can fetch."
+    ),
+    responses={
+        **AUTH_RESPONSES,
+        200: {
+            "description": "Item image uploaded successfully.",
+            "content": {
+                "application/json": {
+                    "example": {"url": "https://cdn.example.com/clothing-images/user-123/item.jpg"}
+                }
+            },
+        },
+        400: {
+            "model": ErrorResponse,
+            "description": "Invalid file type or file size exceeds limit.",
+            "content": {"application/json": {"example": {"detail": "File must be an image"}}},
+        },
+        500: {
+            "model": ErrorResponse,
+            "description": "Unexpected upload failure.",
+            "content": {"application/json": {"example": {"detail": "Failed to upload image"}}},
+        },
+    },
+)
+async def upload_item_image(
+    image: UploadFile = File(..., description="Clothing item image for try-on"),
+    current_user: User = Depends(get_current_user),
+) -> dict:
+    """Upload a clothing item image to the clothing-images bucket.
+
+    Previously this path was hitting /upload-photo which writes to the
+    user-photos bucket, mixing item blobs into a bucket meant for full-body
+    photos. This endpoint puts item blobs where they belong.
+    """
+    try:
+        if not image.content_type or not image.content_type.startswith("image/"):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="File must be an image",
+            )
+
+        image_data = await image.read()
+        if len(image_data) > 10 * 1024 * 1024:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Image must be less than 10MB",
+            )
+
+        file_name = image.filename or f"item-{uuid.uuid4()}.jpg"
+        public_url = await upload_image(
+            user_id=current_user.id,
+            file_data=image_data,
+            file_name=file_name,
+            bucket="clothing-images",
+            content_type=image.content_type or "image/jpeg",
+        )
+
+        logger.info(f"Uploaded item image for user {current_user.id}")
+        return {"url": public_url}
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Failed to upload item image: {e}", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to upload image",
         )
 
 

--- a/backend/app/routers/tryon.py
+++ b/backend/app/routers/tryon.py
@@ -1,7 +1,11 @@
 """Try-on endpoints for AI-generated outfit visualization."""
 
+import asyncio
 import logging
 import uuid
+from collections import defaultdict, deque
+from time import monotonic
+
 import httpx
 from fastapi import APIRouter, Body, Depends, File, HTTPException, UploadFile, status
 
@@ -19,6 +23,38 @@ from app.services.supabase import (
     delete_user_photo,
     get_supabase_client,
 )
+
+
+# Per-user rate limit on try-on generation. Each Gemini call is paid, so a
+# determined user (or a buggy frontend) can run up a real bill in seconds
+# without this guard. In-memory only — survives a single worker process but
+# not restarts or multi-worker deploys. For a multi-worker setup, move this
+# to Redis or a Supabase counter table.
+_TRYON_WINDOW_SECONDS = 60
+_TRYON_MAX_PER_WINDOW = 10
+_tryon_history: dict[str, deque] = defaultdict(deque)
+_tryon_history_lock = asyncio.Lock()
+
+
+async def _check_tryon_rate_limit(user_id: str) -> None:
+    """Sliding-window rate limit; raises 429 with Retry-After when exceeded."""
+    now = monotonic()
+    cutoff = now - _TRYON_WINDOW_SECONDS
+    async with _tryon_history_lock:
+        history = _tryon_history[user_id]
+        while history and history[0] < cutoff:
+            history.popleft()
+        if len(history) >= _TRYON_MAX_PER_WINDOW:
+            retry_after = max(1, int(history[0] + _TRYON_WINDOW_SECONDS - now) + 1)
+            raise HTTPException(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                detail=(
+                    f"Try-on rate limit hit ({_TRYON_MAX_PER_WINDOW} per "
+                    f"{_TRYON_WINDOW_SECONDS}s). Try again in {retry_after}s."
+                ),
+                headers={"Retry-After": str(retry_after)},
+            )
+        history.append(now)
 
 
 async def _cleanup_user_photo(user_id: str, user_photo_url: str) -> None:
@@ -308,6 +344,9 @@ async def try_on_single(
     current_user: User = Depends(get_current_user),
 ) -> TryOnResponse:
     """Generate try-on image with a single clothing item."""
+    # 0. Rate limit BEFORE doing any expensive work (Gemini, downloads).
+    await _check_tryon_rate_limit(current_user.id)
+
     # 1. Validation (HTTP 400)
     await validate_image_url(request.user_photo_url)
     await validate_image_url(request.item_image_url)
@@ -436,6 +475,9 @@ async def try_on_outfit(
     current_user: User = Depends(get_current_user),
 ) -> TryOnResponse:
     """Generate try-on image with a complete outfit."""
+    # 0. Rate limit BEFORE doing any expensive work.
+    await _check_tryon_rate_limit(current_user.id)
+
     # 1. Validation
     await validate_image_url(request.user_photo_url)
 

--- a/backend/app/routers/tryon.py
+++ b/backend/app/routers/tryon.py
@@ -18,8 +18,28 @@ from app.services.gemini import generate_tryon_single, generate_tryon_outfit
 from app.services.supabase import (
     upload_generated_image,
     upload_image,
+    delete_user_photo,
     get_supabase_client,
 )
+
+
+async def _cleanup_user_photo(user_id: str, user_photo_url: str) -> None:
+    """Best-effort delete of a user-photo URL that we own.
+
+    Guard ensures we only delete URLs scoped to this user's path in the
+    user-photos bucket — an external URL the caller passed in shouldn't be
+    touched. Any deletion failure is logged but doesn't disrupt the response.
+    """
+    if not user_photo_url or "/user-photos/" not in user_photo_url:
+        return
+    # Path inside user-photos bucket starts with {user_id}/, so confirm before
+    # deleting to avoid cross-user removal even with a forged URL.
+    if f"/user-photos/{user_id}/" not in user_photo_url:
+        return
+    try:
+        await delete_user_photo(user_photo_url)
+    except Exception as e:
+        logger.warning(f"Failed to delete user photo after try-on: {e}")
 
 logger = logging.getLogger(__name__)
 
@@ -293,9 +313,9 @@ async def try_on_single(
     # 1. Validation (HTTP 400)
     await validate_image_url(request.user_photo_url)
     await validate_image_url(request.item_image_url)
-    
-    # 2. Service Call
-    # Note: Service now suppresses exceptions and returns success=False
+
+    # 2. Service Call — user photo is cleaned up in finally regardless of outcome
+    # so storage doesn't grow unboundedly per try-on attempt.
     try:
         result = await generate_tryon_single(
             user_image_url=request.user_photo_url,
@@ -303,18 +323,17 @@ async def try_on_single(
             item=request.item,
             high_quality=True,
         )
-        
-        # Explicit check for service failure (Replacing previous GeminiError catch)
+
         if not result.success:
             logger.error(f"Gemini error for user {current_user.id}: {result.error}")
             raise HTTPException(
-                status_code=status.HTTP_502_BAD_GATEWAY, 
+                status_code=status.HTTP_502_BAD_GATEWAY,
                 detail=result.error or "AI service failed to generate image."
             )
 
-        # 3. Save Image (Retaining your original error catching logic)
+        # 3. Save Image
         stored_url = await _save_generated_image(current_user.id, result.generated_image_url)
-        
+
         return TryOnResponse(
             success=True,
             generated_image_url=stored_url,
@@ -322,16 +341,15 @@ async def try_on_single(
         )
 
     except ValueError as e:
-        # Catches validation errors during save/processing
         logger.warning(f"Validation error for user {current_user.id}: {e}")
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
     except HTTPException:
-        # Re-raise HTTPExceptions (like the 502 above)
         raise
     except Exception as e:
-        # Catch-all for unexpected storage/processing errors
         logger.error(f"Unexpected error for user {current_user.id}: {e}", exc_info=True)
         raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="Failed to process generated image.")
+    finally:
+        await _cleanup_user_photo(current_user.id, request.user_photo_url)
 
 
 @router.post(
@@ -421,31 +439,28 @@ async def try_on_outfit(
     """Generate try-on image with a complete outfit."""
     # 1. Validation
     await validate_image_url(request.user_photo_url)
-    
+
     # Loop over list of tuples [(url, item), ...]
     for img_url, _ in request.item_images:
         await validate_image_url(img_url)
-    
-    # 2. Service Call
+
+    # 2. Service Call — user photo cleaned up in finally regardless of outcome.
     try:
-        # Pass item_images directly (it's already the list of tuples the service expects)
         result = await generate_tryon_outfit(
             user_image_url=request.user_photo_url,
             item_images=request.item_images,
             high_quality=True,
         )
-        
-        # Explicit check for service failure
+
         if not result.success:
             logger.error(f"Gemini error for user {current_user.id}: {result.error}")
             raise HTTPException(
-                status_code=status.HTTP_502_BAD_GATEWAY, 
+                status_code=status.HTTP_502_BAD_GATEWAY,
                 detail=result.error or "AI service failed to generate image."
             )
 
-        # 3. Save Image
         stored_url = await _save_generated_image(current_user.id, result.generated_image_url)
-        
+
         return TryOnResponse(
             success=True,
             generated_image_url=stored_url,
@@ -460,6 +475,8 @@ async def try_on_outfit(
     except Exception as e:
         logger.error(f"Unexpected error for user {current_user.id}: {e}", exc_info=True)
         raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="Failed to process generated image.")
+    finally:
+        await _cleanup_user_photo(current_user.id, request.user_photo_url)
 
 
 async def _save_generated_image(user_id: str, data_url: str) -> str:

--- a/backend/app/routers/tryon.py
+++ b/backend/app/routers/tryon.py
@@ -1,6 +1,5 @@
 """Try-on endpoints for AI-generated outfit visualization."""
 
-import base64
 import logging
 import uuid
 import httpx
@@ -16,7 +15,6 @@ from app.models.schemas import (
 )
 from app.services.gemini import generate_tryon_single, generate_tryon_outfit
 from app.services.supabase import (
-    upload_generated_image,
     upload_image,
     delete_user_photo,
     get_supabase_client,
@@ -331,12 +329,13 @@ async def try_on_single(
                 detail=result.error or "AI service failed to generate image."
             )
 
-        # 3. Save Image
-        stored_url = await _save_generated_image(current_user.id, result.generated_image_url)
-
+        # No storage upload here — return the data URL directly. The image
+        # only gets uploaded to Supabase when the user commits by saving an
+        # outfit (see create_outfit), so try-ons the user never saves don't
+        # leave orphan files in storage.
         return TryOnResponse(
             success=True,
-            generated_image_url=stored_url,
+            generated_image_url=result.generated_image_url,
             processing_time=result.processing_time,
         )
 
@@ -459,11 +458,11 @@ async def try_on_outfit(
                 detail=result.error or "AI service failed to generate image."
             )
 
-        stored_url = await _save_generated_image(current_user.id, result.generated_image_url)
-
+        # No storage upload here — return the data URL directly (see /single
+        # endpoint for rationale).
         return TryOnResponse(
             success=True,
-            generated_image_url=stored_url,
+            generated_image_url=result.generated_image_url,
             processing_time=result.processing_time,
         )
 
@@ -477,36 +476,3 @@ async def try_on_outfit(
         raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="Failed to process generated image.")
     finally:
         await _cleanup_user_photo(current_user.id, request.user_photo_url)
-
-
-async def _save_generated_image(user_id: str, data_url: str) -> str:
-    """Extract image from data URL and upload to Supabase Storage."""
-    if not data_url or not data_url.startswith("data:"):
-        return data_url
-    
-    try:
-        # Parse base64 data URL
-        header, b64_data = data_url.split(",", 1)
-        image_bytes = base64.b64decode(b64_data)
-        
-        # Determine extension from header
-        ext = "png"
-        content_type = "image/png"
-        
-        if "image/jpeg" in header:
-            ext = "jpg"
-            content_type = "image/jpeg"
-        elif "image/webp" in header:
-            ext = "webp"
-            content_type = "image/webp"
-
-        # Upload
-        return await upload_generated_image(
-            user_id=user_id,
-            image_data=image_bytes,
-            outfit_id=str(uuid.uuid4()),
-            # Pass content_type if your upload function supports it, otherwise it defaults
-        )
-    except Exception as e:
-        # This will be caught by the outer try/except in the endpoint
-        raise ValueError(f"Invalid image data: {str(e)}")

--- a/backend/app/services/gemini.py
+++ b/backend/app/services/gemini.py
@@ -10,6 +10,7 @@ Models:
 
 import base64
 import httpx
+import logging
 import time
 from io import BytesIO
 from PIL import Image
@@ -20,6 +21,9 @@ from google.genai.errors import APIError
 
 from app.config import settings
 from app.models.schemas import ClothingItemBase, TryOnResponse
+
+
+logger = logging.getLogger(__name__)
 
 
 # Initialize client - picks up GEMINI_API_KEY from environment
@@ -65,9 +69,9 @@ def build_tryon_prompt(items: list[ClothingItemBase], single_item: bool = False)
         #     desc += f" by {item.brand}"
         # if item.color:
         #     desc += f" in {item.color.name}"
-        print(f"Building prompt for single item: {desc}")
-            
-        return f"""Generate a realistic image of the person in the first photo 
+        logger.debug(f"Building prompt for single item: {desc}")
+
+        return f"""Generate a realistic image of the person in the first photo
                 wearing the {desc} shown in the second photo.
 
                 Keep the person's face, body proportions, and pose exactly the same.
@@ -133,6 +137,7 @@ async def generate_tryon_single(
         model = MODEL_HIGH_QUALITY if high_quality else TRYON_MODEL
         
         # Generate image
+        logger.info(f"Gemini try-on starting: model={model}, items=1")
         response = await client.aio.models.generate_content(
             model=model,
             contents=[prompt, user_image, item_image],
@@ -140,10 +145,12 @@ async def generate_tryon_single(
                 response_modalities=["IMAGE"],
             )
         )
-        
-        # Calculate time (useful for logging, even if not returned)
+
         processing_time = time.time() - start_time
-        print(f"Gemini generation took: {processing_time:.2f}s")
+        logger.info(
+            f"Gemini try-on complete: model={model}, items=1, "
+            f"took={processing_time:.2f}s"
+        )
         
         # Extract generated image
         generated_image_data = _extract_image_from_response(response)
@@ -210,6 +217,9 @@ async def generate_tryon_outfit(
         model = MODEL_HIGH_QUALITY if high_quality else TRYON_MODEL
         
         # Generate image
+        logger.info(
+            f"Gemini try-on starting: model={model}, items={len(items)}"
+        )
         response = await client.aio.models.generate_content(
             model=model,
             contents=contents,
@@ -217,9 +227,12 @@ async def generate_tryon_outfit(
                 response_modalities=["IMAGE"],
             )
         )
-        
+
         processing_time = time.time() - start_time
-        print(f"Gemini generation took: {processing_time:.2f}s")
+        logger.info(
+            f"Gemini try-on complete: model={model}, items={len(items)}, "
+            f"took={processing_time:.2f}s"
+        )
         
         # Extract generated image
         generated_image_data = _extract_image_from_response(response)

--- a/backend/app/services/supabase.py
+++ b/backend/app/services/supabase.py
@@ -11,6 +11,8 @@ Schema matches: backend/supabase_schema.sql
 NOTE: Uses async client (acreate_client) for non-blocking operations.
 """
 
+import base64
+import logging
 import time
 from typing import Optional
 
@@ -259,24 +261,58 @@ async def create_outfit(
     outfit: OutfitCreate,
     generated_image_url: Optional[str] = None,
 ) -> OutfitResponse:
-    """Create a new outfit with its items."""
-    supabase = await get_supabase_client()
-    
-    final_image_url = generated_image_url or outfit.generated_image_url
+    """Create a new outfit with its items.
 
+    If generated_image_url is a base64 data URL (handed back from the try-on
+    endpoint), the file is uploaded to generated-images AFTER the outfit row
+    exists so the storage path can include the real outfit_id. This way the
+    try-on endpoint never creates orphan files for try-ons the user doesn't
+    save — the upload only happens here, gated by the user committing.
+    """
+    supabase = await get_supabase_client()
+
+    final_image_url = generated_image_url or outfit.generated_image_url
+    is_pending_data_url = (
+        isinstance(final_image_url, str) and final_image_url.startswith("data:")
+    )
+
+    # Insert the outfit row first WITHOUT the (very large) data URL — we'll
+    # update it with the real public URL once the file is uploaded.
     outfit_data = {
         "user_id": user_id,
         "name": outfit.name,
-        "generated_image_url": final_image_url,
+        "generated_image_url": None if is_pending_data_url else final_image_url,
     }
-    
+
     result = await supabase.table("outfits").insert(outfit_data).execute()
-    
+
     if not result.data:
         raise ValueError("Failed to create outfit")
-    
+
     outfit_id = result.data[0]["id"]
-    
+
+    # Now upload the data URL using the real outfit_id and patch the row.
+    if is_pending_data_url:
+        try:
+            stored_url = await upload_data_url_image(
+                user_id=user_id,
+                data_url=final_image_url,
+                outfit_id=outfit_id,
+            )
+            await (
+                supabase.table("outfits")
+                .update({"generated_image_url": stored_url})
+                .eq("id", outfit_id)
+                .execute()
+            )
+        except Exception as e:
+            # Don't fail the outfit save if the image upload fails — the
+            # outfit metadata is the primary record. Log and continue with
+            # a null generated_image_url so the user still has their outfit.
+            logging.getLogger(__name__).warning(
+                f"Outfit {outfit_id} saved but image upload failed: {e}"
+            )
+
     # Link clothing items to outfit with position
     if outfit.item_ids:
         outfit_items = [
@@ -288,7 +324,7 @@ async def create_outfit(
             for position, item_id in enumerate(outfit.item_ids)
         ]
         await supabase.table("outfit_items").insert(outfit_items).execute()
-    
+
     return await get_outfit(outfit_id, user_id)
 
 
@@ -574,6 +610,40 @@ async def upload_generated_image(
         file_name,
         bucket="generated-images",
         content_type="image/png",
+    )
+
+
+async def upload_data_url_image(
+    user_id: str,
+    data_url: str,
+    outfit_id: str,
+) -> str:
+    """Decode a `data:image/...;base64,...` URL and upload to generated-images.
+
+    Used by create_outfit to persist the try-on image only when the user
+    commits to saving the outfit, avoiding orphan files for try-ons that
+    were generated but never saved.
+    """
+    if not data_url or not data_url.startswith("data:"):
+        raise ValueError("upload_data_url_image requires a data: URL")
+
+    header, b64_data = data_url.split(",", 1)
+    image_bytes = base64.b64decode(b64_data)
+
+    # Default to PNG; respect declared mime if present.
+    content_type = "image/png"
+    if "image/jpeg" in header:
+        content_type = "image/jpeg"
+    elif "image/webp" in header:
+        content_type = "image/webp"
+
+    file_name = f"tryon_{outfit_id}.{content_type.split('/')[1] if '/' in content_type else 'png'}"
+    return await upload_image(
+        user_id,
+        image_bytes,
+        file_name,
+        bucket="generated-images",
+        content_type=content_type,
     )
 
 

--- a/frontend/src/app/style/components/TryOnModal.tsx
+++ b/frontend/src/app/style/components/TryOnModal.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { tryOnSingle, uploadUserPhoto } from '@/lib/api'
+import { tryOnSingle, uploadUserPhoto, uploadItemImage } from '@/lib/api'
 import type { ClothingItemBase } from '@/types'
 import ImageUploadZone from './shared/ImageUploadZone'
 import TryOnResult from './shared/TryOnResult'
@@ -57,21 +57,8 @@ export default function TryOnModal({
 
       let itemUploadUrl = itemImageUrl
       if (itemImageBlob) {
-        const itemUploadFormData = new FormData()
-        itemUploadFormData.append('image', itemImageBlob)
-        const itemUploadResponse = await fetch(
-          `${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'}/api/try-on/upload-photo`,
-          {
-            method: 'POST',
-            headers: { Authorization: `Bearer ${token}` },
-            body: itemUploadFormData,
-          },
-        )
-        if (!itemUploadResponse.ok) {
-          throw new Error('Failed to upload item image')
-        }
-        const itemUploadData = await itemUploadResponse.json()
-        itemUploadUrl = itemUploadData.url
+        // Item blobs go to the clothing-images bucket, not user-photos.
+        itemUploadUrl = await uploadItemImage(itemImageBlob, token)
       }
 
       const response = await tryOnSingle(

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -203,8 +203,8 @@ export async function uploadItemImage(
 ): Promise<string> {
   const formData = new FormData()
   formData.append('image', imageBlob, `item-${Date.now()}.jpg`)
-  
-  const response = await fetch(`${API_BASE_URL}/api/try-on/upload-photo`, {
+
+  const response = await fetch(`${API_BASE_URL}/api/try-on/upload-item-image`, {
     method: 'POST',
     headers: {
       'Authorization': `Bearer ${token}`,


### PR DESCRIPTION
## Summary

First of three PRs from the try-on flow audit. This one closes the "money and disk" holes: every try-on attempt was permanently growing storage with no cleanup, and Gemini calls had no rate limit.

**Storage hygiene**
- **Item blobs now go to the `clothing-images` bucket** via a new `/api/try-on/upload-item-image` endpoint. Previously `uploadItemImage` and an inline fetch in `TryOnModal` posted to `/upload-photo`, mixing item blobs into the `user-photos` bucket. (C3)
- **User photos cleaned up after try-on.** Best-effort `_cleanup_user_photo` in a `finally` clause on both `/single` and `/outfit`. Guarded so it only deletes URLs containing `/user-photos/{user_id}/` — external URLs or forged paths cannot trigger cross-user deletion. (C1)
- **Generated-image upload deferred to outfit-save.** Try-on endpoints return the base64 data URL directly. `create_outfit` detects data URLs, inserts the outfit row first, then uploads using the actual `outfit_id` and patches the row. Try-ons the user never saves create zero files. Try-ons the user saves are stored under a path tied to the real outfit so `delete_outfit` cleans them up correctly. (C2)

**Cost controls**
- **Per-user rate limit on Gemini calls.** Sliding window (10 per 60s) hit at the top of `/single` and `/outfit` before any expensive work. Returns 429 with `Retry-After` on excess. In-memory only — documented inline for multi-worker upgrade path. (C4)

**Observability**
- **Replaced bare `print()` with `logger.info` in `gemini.py`**, including model name and item count per call. Useful for cost tracing now that the rate limiter is in place. (L23)
