### PR TITLE
feat(tryon): error surfacing & retries

### DIFF
--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -231,6 +231,13 @@ class TryOnResponse(BaseModel):
     """Response body for POST /api/try-on"""
     success: bool = True
     error: Optional[str] = None
+    error_kind: Optional[Literal[
+        "timeout",         # Gemini exceeded the timeout (gateway timeout)
+        "api_error",       # Gemini service error / rate limit (service unavailable)
+        "image_fetch",     # Couldn't load user/item image from URL (bad input)
+        "validation",      # Content moderation or malformed Gemini response (bad input)
+        "unexpected",      # Anything else (internal server error)
+    ]] = Field(None, description="Machine-readable error category — drives HTTP status mapping")
     generated_image_url: Optional[str] = None  # Made optional for error cases
     processing_time: Optional[float] = Field(None, description="Time in seconds") # Made optional
 

--- a/backend/app/routers/tryon.py
+++ b/backend/app/routers/tryon.py
@@ -91,26 +91,43 @@ AUTH_RESPONSES = {
 
 
 async def validate_image_url(url: str) -> None:
-    """Validate that an image URL is accessible."""
-    # Skip validation for data URLs
+    """Validate that a URL points at a reachable image.
+
+    Checks:
+    - 2xx status (was previously "anything <400 plus 405")
+    - Content-Type starts with image/ when present
+
+    A 405 from the server is treated as "HEAD not supported" and lets the
+    request through; the GET inside fetch_image_as_pil will surface the
+    real failure if the URL is broken. Data URLs are exempt entirely.
+    """
     if url.startswith("data:"):
         return
-        
+
     try:
         async with httpx.AsyncClient() as client:
             response = await client.head(url, timeout=5.0)
-            if response.status_code >= 400:
-                # Some servers block HEAD, allow if 405 Method Not Allowed
-                if response.status_code == 405:
-                    return
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=f"Image URL not accessible: {url}",
-                )
     except httpx.RequestError:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Could not reach image URL: {url}",
+        )
+
+    if response.status_code == 405:
+        # Server blocks HEAD; rely on the downstream GET.
+        return
+
+    if not 200 <= response.status_code < 300:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Image URL returned status {response.status_code}",
+        )
+
+    content_type = response.headers.get("content-type", "").lower()
+    if content_type and not content_type.startswith("image/"):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"URL is not an image (Content-Type: {content_type})",
         )
 
 

--- a/backend/app/routers/tryon.py
+++ b/backend/app/routers/tryon.py
@@ -27,6 +27,18 @@ from app.services.supabase import (
 )
 
 
+# Map service-layer error categories (TryOnResponse.error_kind) onto the
+# HTTP status the endpoint should return. Default 502 mirrors the previous
+# behavior; specific kinds get more accurate codes.
+_ERROR_KIND_TO_STATUS = {
+    "timeout": status.HTTP_504_GATEWAY_TIMEOUT,
+    "api_error": status.HTTP_503_SERVICE_UNAVAILABLE,
+    "image_fetch": status.HTTP_400_BAD_REQUEST,
+    "validation": status.HTTP_400_BAD_REQUEST,
+    "unexpected": status.HTTP_500_INTERNAL_SERVER_ERROR,
+}
+
+
 # Upload validation: cap each image side at 4096 px. Larger images get
 # rejected by Gemini anyway (and cost more to process), and they're a
 # common decompression-bomb-adjacent pattern we'd rather block at the
@@ -438,10 +450,15 @@ async def try_on_single(
         )
 
         if not result.success:
-            logger.error(f"Gemini error for user {current_user.id}: {result.error}")
+            logger.error(
+                f"Gemini error for user {current_user.id}: "
+                f"kind={result.error_kind}, msg={result.error}"
+            )
             raise HTTPException(
-                status_code=status.HTTP_502_BAD_GATEWAY,
-                detail=result.error or "AI service failed to generate image."
+                status_code=_ERROR_KIND_TO_STATUS.get(
+                    result.error_kind, status.HTTP_502_BAD_GATEWAY
+                ),
+                detail=result.error or "AI service failed to generate image.",
             )
 
         # No storage upload here — return the data URL directly. The image
@@ -570,10 +587,15 @@ async def try_on_outfit(
         )
 
         if not result.success:
-            logger.error(f"Gemini error for user {current_user.id}: {result.error}")
+            logger.error(
+                f"Gemini error for user {current_user.id}: "
+                f"kind={result.error_kind}, msg={result.error}"
+            )
             raise HTTPException(
-                status_code=status.HTTP_502_BAD_GATEWAY,
-                detail=result.error or "AI service failed to generate image."
+                status_code=_ERROR_KIND_TO_STATUS.get(
+                    result.error_kind, status.HTTP_502_BAD_GATEWAY
+                ),
+                detail=result.error or "AI service failed to generate image.",
             )
 
         # No storage upload here — return the data URL directly (see /single

--- a/backend/app/routers/tryon.py
+++ b/backend/app/routers/tryon.py
@@ -446,7 +446,6 @@ async def try_on_single(
             user_image_url=request.user_photo_url,
             item_image_url=request.item_image_url,
             item=request.item,
-            high_quality=True,
         )
 
         if not result.success:
@@ -583,7 +582,6 @@ async def try_on_outfit(
         result = await generate_tryon_outfit(
             user_image_url=request.user_photo_url,
             item_images=request.item_images,
-            high_quality=True,
         )
 
         if not result.success:

--- a/backend/app/routers/tryon.py
+++ b/backend/app/routers/tryon.py
@@ -4,10 +4,12 @@ import asyncio
 import logging
 import uuid
 from collections import defaultdict, deque
+from io import BytesIO
 from time import monotonic
 
 import httpx
 from fastapi import APIRouter, Body, Depends, File, HTTPException, UploadFile, status
+from PIL import Image, UnidentifiedImageError
 
 from app.middleware.auth import get_current_user
 from app.models.schemas import (
@@ -23,6 +25,56 @@ from app.services.supabase import (
     delete_user_photo,
     get_supabase_client,
 )
+
+
+# Upload validation: cap each image side at 4096 px. Larger images get
+# rejected by Gemini anyway (and cost more to process), and they're a
+# common decompression-bomb-adjacent pattern we'd rather block at the
+# boundary.
+MAX_IMAGE_DIMENSION = 4096
+
+
+def _validate_image_bytes(data: bytes) -> None:
+    """Confirm bytes are a real image and within size limits.
+
+    Trusts the content_type header on its own aren't enough — a malicious or
+    misconfigured client can mark anything as image/jpeg. Pillow's open()
+    raises UnidentifiedImageError on non-image content and DecompressionBomb
+    family on suspicious dimensions; we additionally enforce an explicit
+    per-side cap for actionable error copy.
+    """
+    try:
+        with Image.open(BytesIO(data)) as img:
+            img.verify()
+    except UnidentifiedImageError:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="File is not a valid image",
+        )
+    except Exception:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Could not decode image",
+        )
+
+    # verify() invalidates the image; reopen to read dimensions.
+    try:
+        with Image.open(BytesIO(data)) as img:
+            width, height = img.size
+    except Exception:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Could not read image dimensions",
+        )
+
+    if width > MAX_IMAGE_DIMENSION or height > MAX_IMAGE_DIMENSION:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"Image too large ({width}x{height}px; "
+                f"max {MAX_IMAGE_DIMENSION}px per side)"
+            ),
+        )
 
 
 # Per-user rate limit on try-on generation. Each Gemini call is paid, so a
@@ -177,14 +229,18 @@ async def upload_user_photo(
         
         # Read image data
         image_data = await image.read()
-        
+
         # Validate file size (max 10MB)
         if len(image_data) > 10 * 1024 * 1024:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Image must be less than 10MB",
             )
-        
+
+        # Content-Type alone is client-supplied; verify the bytes are
+        # actually an image of a reasonable size.
+        _validate_image_bytes(image_data)
+
         # Generate unique filename
         file_ext = image.filename.split(".")[-1] if image.filename and "." in image.filename else "jpg"
         file_path = f"user-photos/{current_user.id}/{uuid.uuid4()}.{file_ext}"
@@ -269,6 +325,9 @@ async def upload_item_image(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Image must be less than 10MB",
             )
+
+        # Content-Type alone is client-supplied; verify the bytes.
+        _validate_image_bytes(image_data)
 
         file_name = image.filename or f"item-{uuid.uuid4()}.jpg"
         public_url = await upload_image(

--- a/backend/app/services/gemini.py
+++ b/backend/app/services/gemini.py
@@ -58,6 +58,73 @@ TRYON_MODEL = MODEL_HIGH_QUALITY
 # user (or our connection pool) waiting forever.
 GEMINI_TIMEOUT_SECONDS = 90.0
 
+# Retry once on transient failures (rate limit, 5xx, transient network).
+# A second attempt covers the common "blip" cases without doubling typical
+# cost for genuinely broken requests.
+GEMINI_MAX_RETRIES = 1
+GEMINI_RETRY_BACKOFF_SECONDS = 1.5
+
+
+def _is_transient_api_error(e: APIError) -> bool:
+    """Returns True for retryable Gemini API errors (429 rate limit, 5xx)."""
+    # Defensive: the SDK may expose the HTTP status as either attribute.
+    code = getattr(e, "code", None) or getattr(e, "status_code", None)
+    if isinstance(code, int):
+        return code == 429 or 500 <= code < 600
+    # Fallback: look for known retryable signals in the message.
+    msg = str(e).lower()
+    return any(
+        s in msg
+        for s in ("rate limit", "429", "500", "502", "503", "504", "internal error")
+    )
+
+
+async def _call_gemini_with_retry(call_factory, *, label: str):
+    """Call a Gemini coroutine factory with one retry on transient failures.
+
+    `call_factory` must be a zero-arg callable returning a fresh coroutine
+    (a lambda over the SDK call). This is important — coroutines can only be
+    awaited once, so a retry needs a new one.
+    """
+    last_error: Optional[BaseException] = None
+    for attempt in range(GEMINI_MAX_RETRIES + 1):
+        try:
+            return await asyncio.wait_for(
+                call_factory(), timeout=GEMINI_TIMEOUT_SECONDS
+            )
+        except asyncio.TimeoutError as e:
+            last_error = e
+            if attempt < GEMINI_MAX_RETRIES:
+                logger.warning(
+                    f"{label} timeout on attempt {attempt + 1}; retrying"
+                )
+                await asyncio.sleep(GEMINI_RETRY_BACKOFF_SECONDS)
+                continue
+            raise
+        except APIError as e:
+            last_error = e
+            if _is_transient_api_error(e) and attempt < GEMINI_MAX_RETRIES:
+                logger.warning(
+                    f"{label} transient APIError on attempt {attempt + 1}: "
+                    f"{e!r}; retrying"
+                )
+                await asyncio.sleep(GEMINI_RETRY_BACKOFF_SECONDS)
+                continue
+            raise
+        except httpx.HTTPError as e:
+            last_error = e
+            if attempt < GEMINI_MAX_RETRIES:
+                logger.warning(
+                    f"{label} HTTP error on attempt {attempt + 1}: "
+                    f"{e!r}; retrying"
+                )
+                await asyncio.sleep(GEMINI_RETRY_BACKOFF_SECONDS)
+                continue
+            raise
+    # Unreachable — the loop always either returns or re-raises.
+    assert last_error is not None
+    raise last_error
+
 
 async def fetch_image_as_pil(image_url: str) -> Image.Image:
     """Fetch an image from URL and return as PIL Image.
@@ -158,17 +225,17 @@ async def generate_tryon_single(
         # Select model
         model = MODEL_HIGH_QUALITY if high_quality else TRYON_MODEL
         
-        # Generate image
+        # Generate image (with retry on transient failures)
         logger.info(f"Gemini try-on starting: model={model}, items=1")
-        response = await asyncio.wait_for(
-            _get_genai_client().aio.models.generate_content(
+        response = await _call_gemini_with_retry(
+            lambda: _get_genai_client().aio.models.generate_content(
                 model=model,
                 contents=[prompt, user_image, item_image],
                 config=types.GenerateContentConfig(
                     response_modalities=["IMAGE"],
                 ),
             ),
-            timeout=GEMINI_TIMEOUT_SECONDS,
+            label="try-on/single",
         )
 
         processing_time = time.time() - start_time
@@ -188,26 +255,34 @@ async def generate_tryon_single(
         
     except asyncio.TimeoutError:
         logger.warning(
-            f"Gemini try-on timed out after {GEMINI_TIMEOUT_SECONDS}s"
+            f"Gemini try-on timed out after {GEMINI_TIMEOUT_SECONDS}s "
+            f"(plus retries)"
         )
         return TryOnResponse(
             success=False,
             error="Try-on timed out. Please try again.",
         )
     except APIError as e:
+        logger.error(f"Gemini APIError after retries: {e!r}")
         return TryOnResponse(
             success=False,
-            error=f"Gemini API error: {str(e)}"
+            error="The AI service is unavailable. Please try again shortly.",
         )
     except httpx.HTTPError as e:
+        logger.warning(f"Image fetch failed: {e!r}")
         return TryOnResponse(
             success=False,
-            error=f"Failed to fetch image: {str(e)}"
+            error="Couldn't load one of the images. Please try again.",
         )
+    except ValueError as e:
+        # _extract_image_from_response raises ValueError with a user-facing
+        # message (e.g. content moderation). Pass it through verbatim.
+        return TryOnResponse(success=False, error=str(e))
     except Exception as e:
+        logger.error(f"Unexpected try-on error: {e!r}", exc_info=True)
         return TryOnResponse(
             success=False,
-            error=f"Unexpected error: {str(e)}"
+            error="Try-on failed unexpectedly. Please try again.",
         )
 
 
@@ -249,19 +324,19 @@ async def generate_tryon_outfit(
         # Select model
         model = MODEL_HIGH_QUALITY if high_quality else TRYON_MODEL
         
-        # Generate image
+        # Generate image (with retry on transient failures)
         logger.info(
             f"Gemini try-on starting: model={model}, items={len(items)}"
         )
-        response = await asyncio.wait_for(
-            _get_genai_client().aio.models.generate_content(
+        response = await _call_gemini_with_retry(
+            lambda: _get_genai_client().aio.models.generate_content(
                 model=model,
                 contents=contents,
                 config=types.GenerateContentConfig(
                     response_modalities=["IMAGE"],
                 ),
             ),
-            timeout=GEMINI_TIMEOUT_SECONDS,
+            label="try-on/outfit",
         )
 
         processing_time = time.time() - start_time
@@ -281,50 +356,79 @@ async def generate_tryon_outfit(
         
     except asyncio.TimeoutError:
         logger.warning(
-            f"Gemini try-on timed out after {GEMINI_TIMEOUT_SECONDS}s"
+            f"Gemini try-on timed out after {GEMINI_TIMEOUT_SECONDS}s "
+            f"(plus retries)"
         )
         return TryOnResponse(
             success=False,
             error="Try-on timed out. Please try again.",
         )
     except APIError as e:
+        logger.error(f"Gemini APIError after retries: {e!r}")
         return TryOnResponse(
             success=False,
-            error=f"Gemini API error: {str(e)}"
+            error="The AI service is unavailable. Please try again shortly.",
         )
     except httpx.HTTPError as e:
+        logger.warning(f"Image fetch failed: {e!r}")
         return TryOnResponse(
             success=False,
-            error=f"Failed to fetch image: {str(e)}"
+            error="Couldn't load one of the images. Please try again.",
         )
+    except ValueError as e:
+        # _extract_image_from_response raises ValueError with a user-facing
+        # message (e.g. content moderation). Pass it through verbatim.
+        return TryOnResponse(success=False, error=str(e))
     except Exception as e:
+        logger.error(f"Unexpected try-on error: {e!r}", exc_info=True)
         return TryOnResponse(
             success=False,
-            error=f"Unexpected error: {str(e)}"
+            error="Try-on failed unexpectedly. Please try again.",
         )
 
 
 def _extract_image_from_response(response) -> str:
     """Extract the generated image from Gemini response.
-    
+
     Returns:
         Base64 data URL (data:image/png;base64,...)
+
+    Raises:
+        ValueError with a user-facing message. The most common non-image
+        outcome is a content-moderation refusal — Gemini returns text
+        explaining why instead of an image. We log the raw refusal for
+        debugging but translate it to actionable user copy.
     """
     if not response.candidates:
-        raise ValueError("No candidates returned")
+        raise ValueError(
+            "We couldn't generate an image. Please try again with a "
+            "different photo."
+        )
 
     for part in response.candidates[0].content.parts:
         if part.inline_data and part.inline_data.mime_type.startswith("image/"):
             b64_data = base64.standard_b64encode(part.inline_data.data).decode("utf-8")
             mime = part.inline_data.mime_type
             return f"data:{mime};base64,{b64_data}"
-    
-    # No image found - check if there's text (error message)
+
+    # No image — typically a content-moderation refusal. Log the raw text
+    # for debugging, but don't expose Google's policy copy to the user.
     for part in response.candidates[0].content.parts:
         if part.text:
-            raise ValueError(f"No image generated. Model response: {part.text}")
-    
-    raise ValueError("No image generated in response")
+            logger.warning(
+                f"Gemini returned text instead of image (likely policy "
+                f"refusal): {part.text[:300]!r}"
+            )
+            raise ValueError(
+                "Your photo couldn't be processed. Try a clear, "
+                "full-body photo of a single person against an "
+                "unobstructed background."
+            )
+
+    raise ValueError(
+        "We couldn't generate an image. Please try again with a "
+        "different photo."
+    )
 
 
 async def check_gemini_health() -> dict:

--- a/backend/app/services/gemini.py
+++ b/backend/app/services/gemini.py
@@ -46,11 +46,12 @@ def _get_genai_client() -> genai.Client:
         _genai_client = genai.Client(api_key=settings.GEMINI_API_KEY)
     return _genai_client
 
-# Models
-MODEL_FAST = "gemini-2.5-flash-image"  # Fast, cost-effective
-MODEL_HIGH_QUALITY = "gemini-3-pro-image-preview"  # High quality (Nano Banana Pro)
-
-# Default model for try-on
+# Models — high quality is the only one wired through; the fast model
+# constant is kept as a reference for anyone wiring up a cost-savings toggle
+# in the future (would need to pipe a request-level flag through to the
+# service and the API surface).
+MODEL_HIGH_QUALITY = "gemini-3-pro-image-preview"  # Nano Banana Pro
+# MODEL_FAST = "gemini-2.5-flash-image"  # Fast/cheap alternative (not currently used)
 TRYON_MODEL = MODEL_HIGH_QUALITY
 
 # Hard ceiling on Gemini generation time. Image-gen typically takes 10-15s;
@@ -154,10 +155,6 @@ def build_tryon_prompt(items: list[ClothingItemBase], single_item: bool = False)
     if single_item and len(items) == 1:
         item = items[0]
         desc = f"{item.category.l2}"
-        # if item.brand:
-        #     desc += f" by {item.brand}"
-        # if item.color:
-        #     desc += f" in {item.color.name}"
         logger.debug(f"Building prompt for single item: {desc}")
 
         return f"""Generate a realistic image of the person in the first photo
@@ -173,10 +170,6 @@ def build_tryon_prompt(items: list[ClothingItemBase], single_item: bool = False)
     item_descriptions = []
     for i, item in enumerate(items, 1):
         desc = f"{i}. {item.category.l2} ({item.category.l1})"
-        # if item.brand:
-        #     desc += f" by {item.brand}"
-        # if item.color:
-        #     desc += f" in {item.color.name}"
         item_descriptions.append(desc)
     
     items_text = "\n".join(item_descriptions)
@@ -199,16 +192,14 @@ async def generate_tryon_single(
     user_image_url: str,
     item_image_url: str,
     item: ClothingItemBase,
-    high_quality: bool = False
 ) -> TryOnResponse:
     """Generate a try-on image with a single clothing item.
-    
+
     Args:
         user_image_url: URL of the user's photo
         item_image_url: URL of the clothing item image
         item: Clothing item metadata
-        high_quality: Use high-quality model (slower, more expensive)
-        
+
     Returns:
         TryOnResponse with generated image data
     """
@@ -223,7 +214,7 @@ async def generate_tryon_single(
         prompt = build_tryon_prompt([item], single_item=True)
         
         # Select model
-        model = MODEL_HIGH_QUALITY if high_quality else TRYON_MODEL
+        model = TRYON_MODEL
         
         # Generate image (with retry on transient failures)
         logger.info(f"Gemini try-on starting: model={model}, items=1")
@@ -293,15 +284,13 @@ async def generate_tryon_single(
 async def generate_tryon_outfit(
     user_image_url: str,
     item_images: list[tuple[str, ClothingItemBase]],
-    high_quality: bool = False
 ) -> TryOnResponse:
     """Generate a try-on image with multiple clothing items (full outfit).
-    
+
     Args:
         user_image_url: URL of the user's photo
         item_images: List of (image_url, item_metadata) tuples
-        high_quality: Use high-quality model (slower, more expensive)
-        
+
     Returns:
         TryOnResponse with generated image data
     """
@@ -326,7 +315,7 @@ async def generate_tryon_outfit(
         contents = [prompt, user_image] + clothing_images
         
         # Select model
-        model = MODEL_HIGH_QUALITY if high_quality else TRYON_MODEL
+        model = TRYON_MODEL
         
         # Generate image (with retry on transient failures)
         logger.info(
@@ -460,7 +449,6 @@ async def check_gemini_health() -> dict:
             "api_key_valid": True,
             "test_response": response.text,
             "tryon_model": TRYON_MODEL,
-            "high_quality_model": MODEL_HIGH_QUALITY,
         }
     except APIError as e:
         return {

--- a/backend/app/services/gemini.py
+++ b/backend/app/services/gemini.py
@@ -13,6 +13,8 @@ import httpx
 import logging
 import time
 from io import BytesIO
+from typing import Optional
+
 from PIL import Image
 
 from google import genai
@@ -26,8 +28,22 @@ from app.models.schemas import ClothingItemBase, TryOnResponse
 logger = logging.getLogger(__name__)
 
 
-# Initialize client - picks up GEMINI_API_KEY from environment
-client = genai.Client(api_key=settings.GEMINI_API_KEY)
+# Lazy client initialization: instantiating at import time meant a missing
+# or invalid GEMINI_API_KEY would crash the whole API at startup, not just
+# the try-on endpoints. Now the key is only required when try-on is actually
+# invoked.
+_genai_client: Optional[genai.Client] = None
+
+
+def _get_genai_client() -> genai.Client:
+    global _genai_client
+    if _genai_client is None:
+        if not settings.GEMINI_API_KEY:
+            raise RuntimeError(
+                "GEMINI_API_KEY is not configured; try-on is unavailable."
+            )
+        _genai_client = genai.Client(api_key=settings.GEMINI_API_KEY)
+    return _genai_client
 
 # Models
 MODEL_FAST = "gemini-2.5-flash-image"  # Fast, cost-effective
@@ -138,7 +154,7 @@ async def generate_tryon_single(
         
         # Generate image
         logger.info(f"Gemini try-on starting: model={model}, items=1")
-        response = await client.aio.models.generate_content(
+        response = await _get_genai_client().aio.models.generate_content(
             model=model,
             contents=[prompt, user_image, item_image],
             config=types.GenerateContentConfig(
@@ -220,7 +236,7 @@ async def generate_tryon_outfit(
         logger.info(
             f"Gemini try-on starting: model={model}, items={len(items)}"
         )
-        response = await client.aio.models.generate_content(
+        response = await _get_genai_client().aio.models.generate_content(
             model=model,
             contents=contents,
             config=types.GenerateContentConfig(
@@ -291,7 +307,7 @@ async def check_gemini_health() -> dict:
     """
     try:
         # Simple text generation to verify API key works
-        response = await client.aio.models.generate_content(
+        response = await _get_genai_client().aio.models.generate_content(
             model="gemini-2.5-flash",
             contents="Say 'ok'",
             config=types.GenerateContentConfig(

--- a/backend/app/services/gemini.py
+++ b/backend/app/services/gemini.py
@@ -261,28 +261,32 @@ async def generate_tryon_single(
         return TryOnResponse(
             success=False,
             error="Try-on timed out. Please try again.",
+            error_kind="timeout",
         )
     except APIError as e:
         logger.error(f"Gemini APIError after retries: {e!r}")
         return TryOnResponse(
             success=False,
             error="The AI service is unavailable. Please try again shortly.",
+            error_kind="api_error",
         )
     except httpx.HTTPError as e:
         logger.warning(f"Image fetch failed: {e!r}")
         return TryOnResponse(
             success=False,
             error="Couldn't load one of the images. Please try again.",
+            error_kind="image_fetch",
         )
     except ValueError as e:
         # _extract_image_from_response raises ValueError with a user-facing
         # message (e.g. content moderation). Pass it through verbatim.
-        return TryOnResponse(success=False, error=str(e))
+        return TryOnResponse(success=False, error=str(e), error_kind="validation")
     except Exception as e:
         logger.error(f"Unexpected try-on error: {e!r}", exc_info=True)
         return TryOnResponse(
             success=False,
             error="Try-on failed unexpectedly. Please try again.",
+            error_kind="unexpected",
         )
 
 
@@ -362,28 +366,32 @@ async def generate_tryon_outfit(
         return TryOnResponse(
             success=False,
             error="Try-on timed out. Please try again.",
+            error_kind="timeout",
         )
     except APIError as e:
         logger.error(f"Gemini APIError after retries: {e!r}")
         return TryOnResponse(
             success=False,
             error="The AI service is unavailable. Please try again shortly.",
+            error_kind="api_error",
         )
     except httpx.HTTPError as e:
         logger.warning(f"Image fetch failed: {e!r}")
         return TryOnResponse(
             success=False,
             error="Couldn't load one of the images. Please try again.",
+            error_kind="image_fetch",
         )
     except ValueError as e:
         # _extract_image_from_response raises ValueError with a user-facing
         # message (e.g. content moderation). Pass it through verbatim.
-        return TryOnResponse(success=False, error=str(e))
+        return TryOnResponse(success=False, error=str(e), error_kind="validation")
     except Exception as e:
         logger.error(f"Unexpected try-on error: {e!r}", exc_info=True)
         return TryOnResponse(
             success=False,
             error="Try-on failed unexpectedly. Please try again.",
+            error_kind="unexpected",
         )
 
 

--- a/backend/app/services/gemini.py
+++ b/backend/app/services/gemini.py
@@ -8,6 +8,7 @@ Models:
 - gemini-3-pro-image-preview: High-quality image generation (Nano Banana Pro)
 """
 
+import asyncio
 import base64
 import httpx
 import logging
@@ -51,6 +52,11 @@ MODEL_HIGH_QUALITY = "gemini-3-pro-image-preview"  # High quality (Nano Banana P
 
 # Default model for try-on
 TRYON_MODEL = MODEL_HIGH_QUALITY
+
+# Hard ceiling on Gemini generation time. Image-gen typically takes 10-15s;
+# 90s is generous but bounded so a hanging upstream call can't leave the
+# user (or our connection pool) waiting forever.
+GEMINI_TIMEOUT_SECONDS = 90.0
 
 
 async def fetch_image_as_pil(image_url: str) -> Image.Image:
@@ -154,12 +160,15 @@ async def generate_tryon_single(
         
         # Generate image
         logger.info(f"Gemini try-on starting: model={model}, items=1")
-        response = await _get_genai_client().aio.models.generate_content(
-            model=model,
-            contents=[prompt, user_image, item_image],
-            config=types.GenerateContentConfig(
-                response_modalities=["IMAGE"],
-            )
+        response = await asyncio.wait_for(
+            _get_genai_client().aio.models.generate_content(
+                model=model,
+                contents=[prompt, user_image, item_image],
+                config=types.GenerateContentConfig(
+                    response_modalities=["IMAGE"],
+                ),
+            ),
+            timeout=GEMINI_TIMEOUT_SECONDS,
         )
 
         processing_time = time.time() - start_time
@@ -177,6 +186,14 @@ async def generate_tryon_single(
             processing_time=processing_time,
         )
         
+    except asyncio.TimeoutError:
+        logger.warning(
+            f"Gemini try-on timed out after {GEMINI_TIMEOUT_SECONDS}s"
+        )
+        return TryOnResponse(
+            success=False,
+            error="Try-on timed out. Please try again.",
+        )
     except APIError as e:
         return TryOnResponse(
             success=False,
@@ -236,12 +253,15 @@ async def generate_tryon_outfit(
         logger.info(
             f"Gemini try-on starting: model={model}, items={len(items)}"
         )
-        response = await _get_genai_client().aio.models.generate_content(
-            model=model,
-            contents=contents,
-            config=types.GenerateContentConfig(
-                response_modalities=["IMAGE"],
-            )
+        response = await asyncio.wait_for(
+            _get_genai_client().aio.models.generate_content(
+                model=model,
+                contents=contents,
+                config=types.GenerateContentConfig(
+                    response_modalities=["IMAGE"],
+                ),
+            ),
+            timeout=GEMINI_TIMEOUT_SECONDS,
         )
 
         processing_time = time.time() - start_time
@@ -259,6 +279,14 @@ async def generate_tryon_outfit(
             processing_time=processing_time,
         )
         
+    except asyncio.TimeoutError:
+        logger.warning(
+            f"Gemini try-on timed out after {GEMINI_TIMEOUT_SECONDS}s"
+        )
+        return TryOnResponse(
+            success=False,
+            error="Try-on timed out. Please try again.",
+        )
     except APIError as e:
         return TryOnResponse(
             success=False,

--- a/backend/app/services/supabase.py
+++ b/backend/app/services/supabase.py
@@ -648,14 +648,18 @@ async def upload_data_url_image(
 
 
 async def delete_image(image_url: str, bucket: str = "clothing-images") -> bool:
-    """Delete an image from Supabase Storage."""
+    """Delete an image from Supabase Storage. Logs (rather than silently
+    swallows) failures so storage/DB drift is observable."""
     supabase = await get_supabase_client()
-    
+
     try:
         path = image_url.split(f"/{bucket}/")[1]
         await supabase.storage.from_(bucket).remove([path])
         return True
-    except Exception:
+    except Exception as e:
+        logging.getLogger(__name__).warning(
+            f"delete_image failed for bucket={bucket} url={image_url!r}: {e!r}"
+        )
         return False
 
 

--- a/frontend/src/app/style/components/TryOnModal.tsx
+++ b/frontend/src/app/style/components/TryOnModal.tsx
@@ -76,7 +76,15 @@ export default function TryOnModal({
       onTryOnComplete?.(response.generated_image_url)
     } catch (err) {
       console.error('Try-on failed:', err)
-      setError('Failed to generate try-on. Please try again.')
+      // Surface the backend's user-facing message (e.g. "Your photo couldn't
+      // be processed. Try a clear, full-body photo...") instead of swallowing
+      // it into a generic "Failed". fetchApi throws Error with the detail
+      // field as the message.
+      setError(
+        err instanceof Error
+          ? err.message
+          : 'Failed to generate try-on. Please try again.',
+      )
       setStep('upload')
     }
   }

--- a/frontend/src/app/style/components/TryonOutfitModal.tsx
+++ b/frontend/src/app/style/components/TryonOutfitModal.tsx
@@ -87,7 +87,12 @@ export default function TryOnOutfitModal({
       setStep('result')
     } catch (err) {
       console.error('Outfit try-on failed:', err)
-      setError('Failed to generate outfit try-on. Please try again.')
+      // Surface backend's user-facing message instead of a generic "Failed".
+      setError(
+        err instanceof Error
+          ? err.message
+          : 'Failed to generate outfit try-on. Please try again.',
+      )
       setStep('upload')
     }
   }


### PR DESCRIPTION
## Summary

Second of two try-on PRs (third PR's scope merged into this one — see below).
**Rebased onto main now that #48 has landed** — diff is clean (8 commits, only this PR's work).

This PR makes try-on failures **actionable** instead of opaque, and tightens input/output validation at every boundary.

### Error surfacing & retries 

- **Lazy Gemini client init** (H8). The client was constructed at module-import time, so a missing/invalid `GEMINI_API_KEY` crashed the whole API at startup. Now wrapped in `_get_genai_client()`.
- **90s timeout on Gemini calls** (C5). `client.aio.models.generate_content` was unbounded. Wrapped in `asyncio.wait_for`.
- **One retry on transient failures** (H9). New `_call_gemini_with_retry` retries with 1.5s backoff on `TimeoutError`, `httpx.HTTPError`, and `APIError` where status is 429 or 5xx. Permanent errors (content moderation, 4xx) short-circuit — no second paid call.
- **Content-moderation refusals translated** (H7). `_extract_image_from_response` no longer leaks Google's policy verbiage. Logs the raw text for debugging; user sees *"Your photo couldn't be processed. Try a clear, full-body photo of a single person against an unobstructed background."*
- **Frontend modals surface `err.message`** (H6) instead of swallowing into `"Failed to generate try-on."`.

### Robustness & polish 

- **Strict URL validation** (H11). `validate_image_url` now requires 2xx status and `Content-Type: image/*` (was accepting anything below 400). 405 fallback preserved for HEAD-blocking servers.
- **Magic-byte + dimension check on upload** (H12, M15). Both `/upload-photo` and `/upload-item-image` now run Pillow's `Image.verify()` after the size check and reject images larger than 4096px per side. Client-supplied `content_type` is no longer trusted.
- **Endpoint error classification** (M19). `TryOnResponse.error_kind: Literal[...]` set by the service; endpoint maps it to the correct HTTP status (timeout → 504, API outage → 503, content moderation → 400, unexpected → 500). Was previously collapsed into 502.
- **Dead code cleanup** (M18, M20, L24). Removed unused `high_quality` parameter (was hard-coded to `True` everywhere) and `MODEL_FAST` constant. Removed commented-out brand/color hints in `build_tryon_prompt`. `delete_image` now logs (warning) on failure instead of silently returning False.
