### PR TITLE
fix(scoring): show formality warnings that affect the score

### DIFF
--- a/backend/app/services/compatibility.py
+++ b/backend/app/services/compatibility.py
@@ -536,9 +536,13 @@ def validate_outfit(
             if not is_compatible:
                 warnings.append(f"{item1.category.l2} and {item2.category.l2} colors may clash")
             
-            # Formality check
+            # Formality check — surface both "warning" and "mismatch" tiers.
+            # The cohesion score deducts for any range above the 0.5 dead-zone,
+            # so a "warning"-tier pair (1 < distance ≤ 2) silently reduced the
+            # score with no visible reason. dedup at the end will collapse
+            # identical strings.
             status, msg = check_formality_compatibility(item1.formality, item2.formality)
-            if status == "mismatch":
+            if status in ("warning", "mismatch"):
                 warnings.append(msg)
             
             # Category pairing check

--- a/backend/tests/unit/test_compatibility.py
+++ b/backend/tests/unit/test_compatibility.py
@@ -779,6 +779,29 @@ def test_formality_warning_text_uses_labels_not_floats():
         assert "5.0" not in w
 
 
+def test_validate_outfit_emits_warning_for_formality_gap_under_mismatch_threshold():
+    """A 1<distance≤2 formality gap deducts from the cohesion score but
+    previously surfaced no warning — users saw a sub-100 score with no
+    visible reason. Now the "warning"-tier message (alongside the existing
+    "mismatch" tier) is surfaced."""
+    base_item = _make_item(
+        "Tops", "T-Shirts", formality=3.0, aesthetics=["Minimalist"]
+    )
+    items = [
+        # 3.0 vs 4.5 → distance 1.5 → "warning" tier, not "mismatch"
+        _make_item("Bottoms", "Jeans", formality=4.5, aesthetics=["Minimalist"]),
+        _make_item("Shoes", "Sneakers", formality=3.0, aesthetics=["Minimalist"]),
+    ]
+    response = compatibility.validate_outfit(items, base_item)
+
+    # Score should drop because formality range is 1.5 (above 0.5 dead-zone)
+    assert response.cohesion_score < 100
+    # And the user should now see a formality warning explaining it.
+    assert any("formality" in w.lower() for w in response.warnings), (
+        f"expected a formality warning, got {response.warnings!r}"
+    )
+
+
 def test_validate_outfit_emits_aesthetic_warning_when_no_shared_tags():
     """validate_outfit previously checked color/formality/pairing pair-wise
     but never surfaced aesthetic warnings. An outfit with zero shared tags


### PR DESCRIPTION
## Summary

Closes the "score under 100 with no visible reason" UX bug.

### What was happening

`calculate_cohesion_score` deducts points whenever the outfit's formality range exceeds the 0.5-level dead-zone — so a 1.5-level gap (e.g. items at formality 3.0 vs 4.5) cost ~10 points. But `validate_outfit` only surfaced a warning when a pair's distance exceeded **2.0** (the "mismatch" tier). The "warning" tier (1 < distance ≤ 2) silently reduced the score and emitted nothing.

Users saw 90/100 with an empty warnings list — no path to understand or fix it.

### What changed

One-line fix in the pair-wise loop:

```diff
- if status == "mismatch":
+ if status in ("warning", "mismatch"):
      warnings.append(msg)
```