### PR TITLE
fix(store): closet quick-add no longer duplicates same-L1 items

### DIFF
--- a/frontend/src/store/styleStore.ts
+++ b/frontend/src/store/styleStore.ts
@@ -695,18 +695,39 @@ export const useStyleStore = create<StyleState>((set, get) => ({
     // Preserve the existing item ID to avoid creating duplicates
     const existingId = item.id
 
+    // The base item already covers its own category slot — refuse to add a
+    // second item there. (Without this guard, base + a closet quick-add of
+    // the same L1 would produce e.g. two Outerwear items, surfacing the
+    // "Too many outerwear pieces" warning from validate_outfit.)
+    const baseItem = get().getBaseItem()
+    if (baseItem?.category?.l1 === outfitItem.category.l1) {
+      return
+    }
+
+    // Same replace-by-category invariant as addOutfitItem: an L1 slot holds
+    // at most one item. Re-quick-adding into the same slot should swap, not
+    // append.
+    const upsertByCategory = (
+      blob: Blob,
+    ): ((state: StyleState) => Partial<StyleState>) => (state) => {
+      const existingIndex = state.outfitItems.findIndex(
+        (oi) => oi.item.category.l1 === outfitItem.category.l1,
+      )
+      const entry = { item: outfitItem, imageBlob: blob, existingId }
+      const newOutfitItems =
+        existingIndex >= 0
+          ? state.outfitItems.map((oi, i) => (i === existingIndex ? entry : oi))
+          : [...state.outfitItems, entry]
+      return { outfitItems: newOutfitItems }
+    }
+
     fetch(item.image_url)
-      .then(res => res.blob())
-      .then(blob => {
-        set((state) => ({
-          outfitItems: [...state.outfitItems, { item: outfitItem, imageBlob: blob, existingId }],
-        }))
+      .then((res) => res.blob())
+      .then((blob) => {
+        set(upsertByCategory(blob))
       })
       .catch(() => {
-        const emptyBlob = new Blob([], { type: 'image/jpeg' })
-        set((state) => ({
-          outfitItems: [...state.outfitItems, { item: outfitItem, imageBlob: emptyBlob, existingId }],
-        }))
+        set(upsertByCategory(new Blob([], { type: 'image/jpeg' })))
       })
   },
 


### PR DESCRIPTION
## Summary

Closes the *"Too many outerwear pieces (2 — max: 1)"* warning the user was hitting in real outfits.

### Root cause

Two divergent code paths add items to the outfit:

- `addOutfitItem` (the upload flow) — correctly **replaces** existing same-L1 items.
- `addClosetItemToOutfit` (the suggestion-panel quick-add) — appended **unconditionally**.

The UI's slot model assumes one item per L1 category, and `validate_outfit`'s `MAX_OUTERWEAR` / `MAX_ACCESSORIES` / duplicate-singleton warnings were written against that invariant. The quick-add path silently broke it.

Two reproduction paths:

1. **Base item L1 + quick-add same L1.** Base is e.g. Outerwear, user quick-adds an Outerwear from the suggestion panel → outfitItems gets the second Outerwear → `validate_outfit` sees `[base outerwear, outfit outerwear]` and warns.
2. **Repeated quick-add into the same slot.** Persistence / hot-reload / race conditions where the slot appears empty momentarily — repeated quick-adds would stack instead of swapping.

