### PR TITLE
refactor(headers): drop the trailing underline from section headers

### DIFF
--- a/frontend/src/app/closet/components/OutfitDetailModal.tsx
+++ b/frontend/src/app/closet/components/OutfitDetailModal.tsx
@@ -320,7 +320,6 @@ function SectionHeader({ title, count }: SectionHeaderProps) {
           {count}
         </span>
       )}
-      <span className="h-px bg-ink" aria-hidden="true" />
     </header>
   )
 }

--- a/frontend/src/app/closet/page.tsx
+++ b/frontend/src/app/closet/page.tsx
@@ -508,7 +508,6 @@ function ItemsView({
               {pad2(filtered.length)}{' '}
               {filtered.length === 1 ? 'piece' : 'pieces'}
             </span>
-            <span className="h-px bg-ink" aria-hidden="true" />
           </header>
 
           <div className="grid grid-cols-4 gap-6 max-md:grid-cols-2 mb-10">
@@ -604,7 +603,6 @@ function OutfitsView({ outfits, onOutfitClick }: OutfitsViewProps) {
         <span className="font-mono text-[11px] uppercase tracking-[0.12em] text-ink-3">
           {pad2(outfits.length)} {outfits.length === 1 ? 'look' : 'looks'}
         </span>
-        <span className="h-px bg-ink" aria-hidden="true" />
       </header>
 
       <div className="grid grid-cols-4 gap-6 max-md:grid-cols-2">

--- a/frontend/src/app/style/components/BuildStep.tsx
+++ b/frontend/src/app/style/components/BuildStep.tsx
@@ -237,7 +237,6 @@ export default function BuildStep() {
                 <span className="font-mono text-[11px] uppercase tracking-[0.12em] text-ink-3">
                   Tops · Bottoms · Shoes
                 </span>
-                <span className="h-px bg-ink" aria-hidden="true" />
               </header>
 
               <div
@@ -289,7 +288,6 @@ export default function BuildStep() {
                 <span className="font-mono text-[11px] uppercase tracking-[0.12em] text-ink-3">
                   Layers · accessories
                 </span>
-                <span className="h-px bg-rule-soft" aria-hidden="true" />
               </header>
 
               <div className="grid gap-6 grid-cols-3 lg:grid-cols-4 max-md:grid-cols-2">

--- a/frontend/src/app/style/components/SummaryStep.tsx
+++ b/frontend/src/app/style/components/SummaryStep.tsx
@@ -159,7 +159,6 @@ export default function SummaryStep() {
               <span className="font-mono text-[11px] uppercase tracking-[0.12em] text-ink-3">
                 {allItems.length} in this look
               </span>
-              <span className="h-px bg-ink" aria-hidden="true" />
             </header>
 
             <div className="grid grid-cols-3 gap-4 max-md:grid-cols-2">
@@ -206,11 +205,10 @@ export default function SummaryStep() {
             if (colorStrip.length === 0) return null
             return (
               <section>
-                <header className="grid grid-cols-[auto_1fr] gap-4 items-baseline pb-[14px] mb-5 border-b border-ink">
+                <header className="pb-[14px] mb-5 border-b border-ink">
                   <span className="font-display text-[24px] leading-none tracking-[-0.015em]">
                     Palette
                   </span>
-                  <span className="h-px bg-ink" aria-hidden="true" />
                 </header>
                 <div className="flex h-12 border border-ink overflow-hidden">
                   {colorStrip.map((hex, i) => (
@@ -231,11 +229,10 @@ export default function SummaryStep() {
         {/* Analysis + actions */}
         <div className="flex flex-col gap-10">
           <section>
-            <header className="grid grid-cols-[auto_1fr] gap-4 items-baseline pb-[14px] mb-5 border-b border-ink">
+            <header className="pb-[14px] mb-5 border-b border-ink">
               <span className="font-display text-[24px] leading-none tracking-[-0.015em]">
                 Cohesion
               </span>
-              <span className="h-px bg-ink" aria-hidden="true" />
             </header>
 
             {isValidating ? (


### PR DESCRIPTION
## Summary

Every section header in the closet and style flows had **two stacked horizontal lines**: a `<span className="h-px bg-ink">` filling the last grid column AND a `border-b border-ink` on the header element. Visually it read as the "underscore everywhere" pattern.

Removed the in-row trailing-line span in all 8 instances. The `border-b` stays as the single visual separator.

### Before
```
TOPS  11 PIECES  ____________________________________________________
___________________________________________________________________________
```

### After
```
TOPS  11 PIECES
___________________________________________________________________________
```
