### PR TITLE
fix(validate-outfit): stop double-counting the base item

### DIFF
--- a/frontend/src/app/style/components/SummaryStep.tsx
+++ b/frontend/src/app/style/components/SummaryStep.tsx
@@ -50,7 +50,12 @@ export default function SummaryStep() {
       hasValidated.current = true
       setIsValidating(true)
       try {
-        const result = await validateOutfit(allItems, baseItem)
+        // allItems is [base, ...outfitItems] — slice off the base since the
+        // backend's validate_outfit re-prepends it. Without this, the base
+        // appears twice in full_outfit and triggers spurious duplicate-L1
+        // warnings (notably "Too many outerwear pieces" when base is Outerwear).
+        const otherItems = allItems.slice(1)
+        const result = await validateOutfit(otherItems, baseItem)
         setValidation(result)
       } catch (error) {
         // Don't fake a score-of-0 response — distinguish "validation failed"


### PR DESCRIPTION
## Summary

Fixes the spurious *"Too many outerwear pieces (2 — max: 1)"* warning when the user's base item is an Outerwear piece.
### Fix

One-line change in `SummaryStep.tsx`:

```diff
-        const result = await validateOutfit(allItems, baseItem)
+        const otherItems = allItems.slice(1)
+        const result = await validateOutfit(otherItems, baseItem)
```

(plus a comment explaining the convention so future Claude doesn't reintroduce the bug)
