### PR TITLE
feat(validation): warnings carry per-dimension score impact

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ Copy `.env.example` files and fill in credentials:
 - Services are stateless functions/classes — no global state
 - Async Supabase client in `services/supabase.py`
 - Color harmony logic uses HSL model with angular hue distance calculations
-- Outfit scoring is penalty-based: starts at 100, deducts -30 (color clash), -40 (formality mismatch >2 levels), -30 (no shared aesthetics)
+- Outfit scoring is penalty-based: starts at 100. Caps: color -40 (10 per incompatible pair), formality -30 (0.5-level dead-zone, then `*10` capped), aesthetic -30 (0 shared tags across 2+ tagged items), pairing -10 (5 per shoe-bottom rule violation). No item-count penalty — UI structurally caps total at MAX_OUTFIT_ITEMS.
 
 ### Frontend (TypeScript/React)
 - Strict TypeScript (`tsconfig.json` has `strict: true`); 2-space indentation; no semicolons
@@ -116,9 +116,9 @@ See `golden-paths.md` for the three canonical user journeys: (1) Style an item I
 ## Domain Concepts
 
 - **Color Harmony**: Analogous (<=30deg), Complementary (165-195deg), Triadic (105-135deg), or Neutral. Hue distance = shortest arc on 360deg wheel.
-- **Formality Levels**: 1 (Casual) to 5 (Black Tie). Distance > 2 warns; > 3 is a mismatch.
+- **Formality Levels**: 1 (Casual) to 5 (Black Tie). Distance > 1 warns; > 2 is a mismatch.
 - **Aesthetics**: 8 tags (Minimalist, Streetwear, Classic, Bohemian, etc.) — items share at least one for cohesion.
-- **Outfit Limits**: MAX_OUTFIT_ITEMS = 6, MAX_ACCESSORIES = 3. Required categories: Tops, Bottoms, Shoes.
+- **Outfit Limits**: MAX_OUTFIT_ITEMS = 6 (5 UI slots + 1 base — structurally enforced). Required L1s: Tops, Bottoms, Shoes. MAX_ACCESSORIES/MAX_OUTERWEAR/duplicate-singleton warnings are defense-in-depth for direct-API access; the UI flow can't reach them.
 - **AI Try-On**: Two Gemini models — `gemini-2.5-flash-image` (fast) and `gemini-3-pro-image-preview` (quality).
 - **Storage Buckets**: `clothing-images` (item photos) and `user-photos` (full-body try-on photos).
 
@@ -139,3 +139,8 @@ Frontend has no automated test runner. Before PRs: run `npm run lint` and manual
 - **CSS cascade layers vs. selector specificity** (`src/styles/system.css`): Tailwind v4 utilities live in `@layer utilities`. Unlayered element rules (e.g., `button { border: 0 }` at the top level of a stylesheet) **win over `@layer utilities` regardless of selector specificity**. The reset block in `system.css` is intentionally wrapped in `@layer base` so utilities like `border-b-2` actually apply to `<button>` elements. If you ever add a tag-level rule to `system.css` outside `@layer base` (`body { ... }`, `input { ... }`, etc.), utility overrides on that element will silently fail. Diagnostic: if a utility works on an inner `<span>` but not on the parent `<button>` with the same class, this is the bug.
 - **Global masthead is route-aware via `usePathname()`** in `src/components/Headers.tsx`. It uses sentence-case labels but renders uppercase via `text-transform: uppercase`. Active route detection uses `pathname.startsWith()` so all sub-routes under `/style/*` mark `Style` as active.
 - **Style flow state is frozen between sessions only by Zustand persistence**. Reloading mid-flow keeps the state. Visiting `/style` directly with no cropped image but non-`upload` step triggers an auto-reset (see `src/app/style/page.tsx`).
+- **Score ↔ warnings must agree.** Every penalty in `calculate_cohesion_score` should surface a warning in `validate_outfit`, and every warning fired from the UI should affect the score. Drift between these two surfaces is a recurring bug class — non-100 scores with no visible reason (PR #50), or warnings the user is told to ignore (PR #52).
+- **Two outfit-add paths share one invariant.** `addOutfitItem` (upload flow) and `addClosetItemToOutfit` (suggestion-panel quick-add) in `store/styleStore.ts` must BOTH enforce one-item-per-L1 (replace, don't append) and refuse base-item-category collisions. They diverged historically — see PR #53.
+- **Try-on returns a base64 data URL; the Supabase upload is deferred to `create_outfit`** (PR #48). Prevents orphan files for try-ons the user never saves. A data URL in `TryOnResponse.generated_image_url` is expected — it becomes a public URL only when an outfit is saved.
+- **Try-on has an in-memory per-user rate limit** (10 calls / 60s) in `routers/tryon.py`. Single-worker only; for multi-worker deploys, swap for Redis or a Supabase counter table.
+- **Don't double-underline section headers.** A `<header>` with `border-b border-ink` AND a child `<span className="h-px bg-ink" />` filling a grid column produces two stacked lines (the "underscores everywhere" pattern). `border-b` is the convention — see PR #54.

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -157,12 +157,26 @@ class ValidateOutfitRequest(BaseModel):
     base_item: ClothingItemBase
 
 
+class OutfitWarning(BaseModel):
+    """A single validation note shown to the user, with its score attribution.
+
+    score_impact is the penalty contribution of the warning's dimension (so
+    multiple warnings of the same dimension all carry the same value — that
+    dimension's total penalty). A value of 0 means the warning is
+    informational only (e.g. composition rules that surface for direct-API
+    callers but don't move the score).
+    """
+    message: str
+    category: Literal["color", "formality", "aesthetic", "pairing", "composition"]
+    score_impact: int = Field(..., le=0, description="Points deducted (negative or zero)")
+
+
 class ValidateOutfitResponse(BaseModel):
     """Response body for POST /api/validate-outfit"""
     is_complete: bool
     cohesion_score: int = Field(..., ge=0, le=100)
     verdict: str
-    warnings: list[str] = Field(default_factory=list)
+    warnings: list[OutfitWarning] = Field(default_factory=list)
     color_strip: list[str] = Field(default_factory=list, description="List of hex colors in outfit")
 
 

--- a/backend/app/services/compatibility.py
+++ b/backend/app/services/compatibility.py
@@ -41,6 +41,7 @@ from app.models.schemas import (
     ClothingItemBase,
     ValidateItemResponse,
     ValidateOutfitResponse,
+    OutfitWarning,
     CategoryRecommendation,
     FormalityRange,
 )
@@ -376,79 +377,57 @@ def get_categories_in_outfit(items: list[ClothingItemBase]) -> dict[str, list[Cl
 def calculate_cohesion_score(items: list[ClothingItemBase], base_item: ClothingItemBase) -> int:
     """Cohesion score (0-100). Penalty-based; single item ⇒ 100.
 
-    - Color: 10 per incompatible pair, capped at 40.
-    - Formality: max(0, range - 0.5) * 10, capped at 30.
-    - Aesthetics: 30 if 2+ tagged items share no tags, else 0.
-    - Pairing: 5 per shoe-bottom rule violation, capped at 10
-      (e.g. Sandals + Suit, Oxfords + Joggers).
-
-    No item-count penalty — UI caps total at MAX_OUTFIT_ITEMS. The
-    "too many items" warning in validate_outfit still downgrades the
-    verdict via get_verdict's no-warnings gate.
+    Caps: see `_score_breakdown` for the full per-dimension formulas. Sum
+    of those (all negative or zero) is applied to a starting score of 100.
     """
-    # Combine all items
+    breakdown = _score_breakdown(items, base_item)
+    return max(0, min(100, 100 + sum(breakdown.values())))
+
+
+def _score_breakdown(
+    items: list[ClothingItemBase], base_item: ClothingItemBase
+) -> dict[str, int]:
+    """Per-dimension penalties (all ≤ 0). Used by both `calculate_cohesion_score`
+    (sums them) and `validate_outfit` (attaches them to warnings for UI display).
+
+    Dimensions:
+    - color: -10 per incompatible pair, capped at -40.
+    - formality: -max(0, range - 0.5) * 10, capped at -30.
+    - aesthetic: -30 when ≥2 tagged items share no tags, else 0.
+    - pairing: -5 per shoe-bottom rule violation, capped at -10.
+
+    No item-count penalty — UI caps total at MAX_OUTFIT_ITEMS.
+    """
     all_items = [base_item] + items
-    total_items = len(all_items)
-    
-    if total_items < 2:
-        return 100  # Single item is always cohesive
-    
-    score = 100
-    
-    # Count incompatible pairs once; the cap and weighting are in the comment
-    # block below where the penalty is computed.
+    if len(all_items) < 2:
+        return {"color": 0, "formality": 0, "aesthetic": 0, "pairing": 0}
+
+    # Pair-wise: color + pairing in one loop.
     incompatible_pairs = 0
+    pairing_violations = 0
     for i in range(len(all_items)):
         for j in range(i + 1, len(all_items)):
             is_compatible, _ = check_color_compatibility(all_items[i].color, all_items[j].color)
             if not is_compatible:
                 incompatible_pairs += 1
-
-    # Color penalty (up to -40 points). Industry sources consistently rank
-    # color discipline (3-color rule, 60-30-10, harmony) as the single most
-    # observable cohesion signal in an outfit — heavier than formality range.
-    color_penalty = min(incompatible_pairs * 10, 40)
-    score -= color_penalty
-
-    # Formality penalty (up to -30 points). Treated as occasion-fit (the
-    # industry framing) rather than the dominant axis; a 0.5-level dead-zone
-    # absorbs small float drift, everything above scales linearly.
-    formality_levels = [float(item.formality) for item in all_items]
-    formality_range = max(formality_levels) - min(formality_levels)
-    formality_penalty = min(max(0.0, formality_range - 0.5) * 10, 30)
-    score -= formality_penalty
-
-    # Aesthetic penalty (up to -30 points). Threshold matches
-    # check_aesthetic_compatibility: ≥1 shared tag is cohesive (no penalty);
-    # 0 shared tags is penalized.
-    all_aesthetics = [set(item.aesthetics) for item in all_items if item.aesthetics]
-    if len(all_aesthetics) >= 2:
-        common_tags = set.intersection(*all_aesthetics)
-        aesthetic_penalty = 0 if common_tags else 30
-    else:
-        aesthetic_penalty = 0  # Single or zero items with tags — nothing to disagree about.
-
-    score -= aesthetic_penalty
-
-    # Pairing penalty (up to -10). Industry treats pairing rules as a "note"
-    # rather than a visual disaster, so the weight is light — 5 per violation,
-    # capped at 10 since the UI has at most one shoe + one bottom pair anyway.
-    pairing_violations = 0
-    for i in range(len(all_items)):
-        for j in range(i + 1, len(all_items)):
             status, _ = check_category_pairing(all_items[i], all_items[j])
             if status == "warning":
                 pairing_violations += 1
-    score -= min(pairing_violations * 5, 10)
 
-    # NB: there used to be an over-max-items penalty here, but the UI caps
-    # each L1 category at one slot (5 outfit slots + 1 base = MAX_OUTFIT_ITEMS),
-    # so it was structurally unreachable. The "Outfit has N items" warning in
-    # validate_outfit stays as defense-in-depth for direct API calls but no
-    # longer moves the score.
+    formality_levels = [float(item.formality) for item in all_items]
+    formality_range = max(formality_levels) - min(formality_levels)
 
-    # Ensure score is between 0-100
-    return max(0, min(100, int(score)))
+    all_aesthetics = [set(item.aesthetics) for item in all_items if item.aesthetics]
+    aesthetic_penalty = 30 if (
+        len(all_aesthetics) >= 2 and not set.intersection(*all_aesthetics)
+    ) else 0
+
+    return {
+        "color": -min(incompatible_pairs * 10, 40),
+        "formality": -int(min(max(0.0, formality_range - 0.5) * 10, 30)),
+        "aesthetic": -aesthetic_penalty,
+        "pairing": -min(pairing_violations * 5, 10),
+    }
 
 
 def get_verdict(score: int, is_complete: bool, warnings: list[str]) -> str:
@@ -493,89 +472,96 @@ def validate_outfit(
     """
     # 1. Combine base_item + items
     full_outfit = [base_item] + items
-    
-    # 2. Check composition
+
+    # 2. Check composition + score breakdown (used to attach per-dimension
+    # score_impact onto warnings).
     is_complete, missing_categories = check_outfit_composition(full_outfit)
-    
-    # 3. Check total items and per-category caps
-    warnings = []
+    breakdown = _score_breakdown(items, base_item)
+    cohesion_score = max(0, min(100, 100 + sum(breakdown.values())))
+
+    warnings: list[OutfitWarning] = []
+
+    def add(message: str, category: str, score_impact: int) -> None:
+        warnings.append(
+            OutfitWarning(
+                message=message, category=category, score_impact=score_impact
+            )
+        )
+
+    # 3. Composition warnings — none move the score (UI caps everything);
+    # they still downgrade the verdict via get_verdict's no-warnings gate.
     if len(full_outfit) > MAX_OUTFIT_ITEMS:
-        # No score impact (UI caps total); still downgrades the verdict
-        # via get_verdict's no-warnings gate.
-        warnings.append(f"Outfit has {len(full_outfit)} items (max: {MAX_OUTFIT_ITEMS})")
-
+        add(f"Outfit has {len(full_outfit)} items (max: {MAX_OUTFIT_ITEMS})", "composition", 0)
     if missing_categories:
-        warnings.append(f"Missing required categories: {', '.join(missing_categories)}")
+        add(f"Missing required categories: {', '.join(missing_categories)}", "composition", 0)
 
-    # Per-category caps and singleton-category checks. MAX_ACCESSORIES and
-    # MAX_OUTERWEAR were unused constants before this; the singleton categories
-    # (Tops/Bottoms/Shoes/Full Body) shouldn't appear more than once.
     items_by_l1 = get_categories_in_outfit(full_outfit)
     if len(items_by_l1.get("Accessories", [])) > MAX_ACCESSORIES:
-        warnings.append(
-            f"Too many accessories ({len(items_by_l1['Accessories'])} — max: {MAX_ACCESSORIES})"
+        add(
+            f"Too many accessories ({len(items_by_l1['Accessories'])} — max: {MAX_ACCESSORIES})",
+            "composition", 0,
         )
     if len(items_by_l1.get("Outerwear", [])) > MAX_OUTERWEAR:
-        warnings.append(
-            f"Too many outerwear pieces ({len(items_by_l1['Outerwear'])} — max: {MAX_OUTERWEAR})"
+        add(
+            f"Too many outerwear pieces ({len(items_by_l1['Outerwear'])} — max: {MAX_OUTERWEAR})",
+            "composition", 0,
         )
     for l1 in ("Tops", "Bottoms", "Shoes", "Full Body"):
         count = len(items_by_l1.get(l1, []))
         if count > 1:
-            warnings.append(f"Multiple {l1} in outfit ({count})")
-    
-    # 4. Calculate cohesion score
-    cohesion_score = calculate_cohesion_score(items, base_item)
-    
-    # 5. Validate each item pair and collect warnings
+            add(f"Multiple {l1} in outfit ({count})", "composition", 0)
+
+    # 4. Pair-wise color + formality + pairing warnings — each tagged with
+    # its dimension's total penalty (so multiple color warnings all show the
+    # same -N representing the dimension's contribution to the score).
     for i in range(len(full_outfit)):
         for j in range(i + 1, len(full_outfit)):
             item1, item2 = full_outfit[i], full_outfit[j]
-            
-            # Color check
-            is_compatible, harmony_type = check_color_compatibility(item1.color, item2.color)
+
+            is_compatible, _ = check_color_compatibility(item1.color, item2.color)
             if not is_compatible:
-                warnings.append(f"{item1.category.l2} and {item2.category.l2} colors may clash")
-            
-            # Formality check — surface both "warning" and "mismatch" tiers.
-            # The cohesion score deducts for any range above the 0.5 dead-zone,
-            # so a "warning"-tier pair (1 < distance ≤ 2) silently reduced the
-            # score with no visible reason. dedup at the end will collapse
-            # identical strings.
+                add(
+                    f"{item1.category.l2} and {item2.category.l2} colors may clash",
+                    "color", breakdown["color"],
+                )
+
             status, msg = check_formality_compatibility(item1.formality, item2.formality)
             if status in ("warning", "mismatch"):
-                warnings.append(msg)
-            
-            # Category pairing check
+                add(msg, "formality", breakdown["formality"])
+
             status, msg = check_category_pairing(item1, item2)
             if status == "warning":
-                warnings.append(msg)
+                add(msg, "pairing", breakdown["pairing"])
 
-    # Outfit-level aesthetic check (not pair-wise to avoid duplicate noise).
+    # 5. Outfit-level aesthetic check (not pair-wise to avoid duplicate noise).
     # Guard `>= 2`: a single tagged item can't disagree with itself, so there's
     # nothing meaningful to warn about until two tagged items exist.
     aesthetic_sets = [set(item.aesthetics) for item in full_outfit if item.aesthetics]
     if len(aesthetic_sets) >= 2 and not set.intersection(*aesthetic_sets):
-        warnings.append("No shared aesthetic tags across the outfit")
+        add("No shared aesthetic tags across the outfit", "aesthetic", breakdown["aesthetic"])
 
-    # Dedupe — pair-wise checks can produce the same warning string from
-    # multiple distinct pairs (e.g. three items at formality 1,1,5 surfaces
-    # the same Casual-vs-Black-Tie mismatch twice). dict.fromkeys preserves
-    # first-seen order on Python 3.7+.
-    warnings = list(dict.fromkeys(warnings))
+    # Dedupe — pair-wise checks can produce the same logical warning from
+    # multiple distinct pairs (e.g. three items at formality 1,1,5 surface
+    # the same Casual-vs-Black-Tie mismatch twice). Match on the (message,
+    # category) pair to keep dedup honest across score-impact updates.
+    seen: set[tuple[str, str]] = set()
+    deduped: list[OutfitWarning] = []
+    for w in warnings:
+        key = (w.message, w.category)
+        if key not in seen:
+            seen.add(key)
+            deduped.append(w)
+    warnings = deduped
 
-    # 6. Build color strip
     color_strip = [item.color.hex for item in full_outfit]
-
-    # 7. Generate verdict
     verdict = get_verdict(cohesion_score, is_complete, warnings)
-    
+
     return ValidateOutfitResponse(
         is_complete=is_complete,
         cohesion_score=cohesion_score,
         verdict=verdict,
         warnings=warnings,
-        color_strip=color_strip
+        color_strip=color_strip,
     )
 
 

--- a/backend/tests/unit/test_compatibility.py
+++ b/backend/tests/unit/test_compatibility.py
@@ -723,7 +723,7 @@ def test_validate_outfit_incomplete():
     assert response.is_complete is False
     assert "Incomplete" in response.verdict
     assert len(response.warnings) > 0
-    assert any("missing" in w.lower() for w in response.warnings)
+    assert any("missing" in w.message.lower() for w in response.warnings)
 
 
 def test_validate_outfit_warns_when_too_many_accessories():
@@ -738,7 +738,7 @@ def test_validate_outfit_warns_when_too_many_accessories():
         _make_item("Accessories", "Bags", aesthetics=["Minimalist"]),  # 4th — over cap
     ]
     response = compatibility.validate_outfit(items, base_item)
-    assert any("accessor" in w.lower() for w in response.warnings)
+    assert any("accessor" in w.message.lower() for w in response.warnings)
 
 
 def test_validate_outfit_warns_when_too_many_outerwear():
@@ -751,7 +751,7 @@ def test_validate_outfit_warns_when_too_many_outerwear():
         _make_item("Outerwear", "Coats", aesthetics=["Minimalist"]),
     ]
     response = compatibility.validate_outfit(items, base_item)
-    assert any("outerwear" in w.lower() for w in response.warnings)
+    assert any("outerwear" in w.message.lower() for w in response.warnings)
 
 
 @pytest.mark.parametrize(
@@ -779,7 +779,7 @@ def test_validate_outfit_warns_on_duplicate_singleton_category(
     ]
     response = compatibility.validate_outfit(items, base_item)
     assert any(
-        duplicate_l1.lower() in w.lower() for w in response.warnings
+        duplicate_l1.lower() in w.message.lower() for w in response.warnings
     ), f"expected a 'Multiple {duplicate_l1}' warning, got {response.warnings!r}"
 
 
@@ -807,10 +807,11 @@ def test_validate_outfit_dedupes_pairwise_warnings():
         _make_item("Shoes", "Sneakers", formality=5.0, aesthetics=["Minimalist"]),
     ]
     response = compatibility.validate_outfit(items, base_item)
-    seen = set()
+    seen: set[tuple[str, str]] = set()
     for w in response.warnings:
-        assert w not in seen, f"duplicate warning: {w!r}"
-        seen.add(w)
+        key = (w.message, w.category)
+        assert key not in seen, f"duplicate warning: {w!r}"
+        seen.add(key)
 
 
 def test_get_verdict_respects_warnings_arg():
@@ -855,9 +856,34 @@ def test_validate_outfit_emits_warning_for_formality_gap_under_mismatch_threshol
     # Score should drop because formality range is 1.5 (above 0.5 dead-zone)
     assert response.cohesion_score < 100
     # And the user should now see a formality warning explaining it.
-    assert any("formality" in w.lower() for w in response.warnings), (
+    assert any("formality" in w.message.lower() for w in response.warnings), (
         f"expected a formality warning, got {response.warnings!r}"
     )
+
+
+def test_validate_outfit_warnings_carry_category_and_score_impact():
+    """Every warning is tagged with its dimension category and the
+    corresponding penalty contribution (or 0 for composition rules)."""
+    base_item = _make_item("Tops", "T-Shirts", formality=2.0, aesthetics=["Streetwear"])
+    items = [
+        # Different aesthetics + 3-level formality gap.
+        _make_item("Bottoms", "Jeans", formality=5.0, aesthetics=["Preppy"]),
+        _make_item("Shoes", "Sneakers", formality=2.0, aesthetics=["Classic"]),
+    ]
+    response = compatibility.validate_outfit(items, base_item)
+
+    categories = {w.category for w in response.warnings}
+    # Formality (3-level gap) and aesthetic (no shared tags) both fire.
+    assert "formality" in categories
+    assert "aesthetic" in categories
+
+    # score_impact aligns with the dimension's total penalty (negative or 0).
+    for w in response.warnings:
+        assert w.score_impact <= 0
+        if w.category == "aesthetic":
+            assert w.score_impact == -30  # no shared tags
+        if w.category == "composition":
+            assert w.score_impact == 0    # composition rules don't move the score
 
 
 def test_validate_outfit_emits_aesthetic_warning_when_no_shared_tags():
@@ -872,7 +898,7 @@ def test_validate_outfit_emits_aesthetic_warning_when_no_shared_tags():
         _make_item("Shoes", "Sneakers", formality=3.0, aesthetics=["Classic"]),
     ]
     response = compatibility.validate_outfit(items, base_item)
-    assert any("aesthetic" in w.lower() for w in response.warnings)
+    assert any("aesthetic" in w.message.lower() for w in response.warnings)
 
 
 def test_validate_outfit_too_many_items():
@@ -886,7 +912,7 @@ def test_validate_outfit_too_many_items():
     response = compatibility.validate_outfit(items, base_item)
 
     # Warning fires, score unaffected, verdict downgraded via no-warnings gate.
-    assert any(str(MAX_OUTFIT_ITEMS) in w for w in response.warnings)
+    assert any(str(MAX_OUTFIT_ITEMS) in w.message for w in response.warnings)
     assert response.cohesion_score == 100
     assert "Excellent" not in response.verdict
 

--- a/frontend/src/app/closet/components/OutfitDetailModal.tsx
+++ b/frontend/src/app/closet/components/OutfitDetailModal.tsx
@@ -251,7 +251,12 @@ export default function OutfitDetailModal({
                       >
                         ※
                       </span>
-                      <span>{warning}</span>
+                      <span className="flex-1">{warning.message}</span>
+                      <span className="font-mono text-[10px] uppercase tracking-[0.1em] text-ink-3 shrink-0">
+                        {warning.score_impact < 0
+                          ? `${warning.score_impact} pts`
+                          : 'style note'}
+                      </span>
                     </li>
                   ))}
                 </ul>

--- a/frontend/src/app/style/components/SummaryStep.tsx
+++ b/frontend/src/app/style/components/SummaryStep.tsx
@@ -289,7 +289,12 @@ export default function SummaryStep() {
                           >
                             ※
                           </span>
-                          <span>{warning}</span>
+                          <span className="flex-1">{warning.message}</span>
+                          <span className="font-mono text-[10px] uppercase tracking-[0.1em] text-ink-3 shrink-0">
+                            {warning.score_impact < 0
+                              ? `${warning.score_impact} pts`
+                              : 'style note'}
+                          </span>
                         </li>
                       ))}
                     </ul>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -134,11 +134,17 @@ export interface ValidateOutfitRequest {
   base_item: ClothingItemBase
 }
 
+export interface OutfitWarning {
+  message: string
+  category: 'color' | 'formality' | 'aesthetic' | 'pairing' | 'composition'
+  score_impact: number  // ≤ 0; 0 = informational only (e.g. composition rules)
+}
+
 export interface ValidateOutfitResponse {
   is_complete: boolean
   cohesion_score: number  // 0-100
   verdict: string
-  warnings: string[]
+  warnings: OutfitWarning[]
   color_strip: string[]  // hex codes
 }
 


### PR DESCRIPTION
## Summary

**Stacked on #55** (`thai/fix/validate-outfit-base-double-count`). After #55 merges, the base auto-updates to `main`.

Each warning now tells the user how much it cost them:

- *"Top and Bottoms colors may clash"* — **`-10 pts`**
- *"Formality gap: Casual vs Formal"* — **`-25 pts`**
- *"No shared aesthetic tags across the outfit"* — **`-30 pts`**
- *"Too many outerwear pieces (2 — max: 1)"* — **`style note`** (composition rule, doesn't move the score)

### Schema change

`ValidateOutfitResponse.warnings` changed from `list[str]` to `list[OutfitWarning]`:

```python
class OutfitWarning(BaseModel):
    message: str
    category: Literal["color", "formality", "aesthetic", "pairing", "composition"]
    score_impact: int  # ≤ 0; 0 = informational only
```

### Attribution model

`score_impact` is the **dimension's total** penalty, not per-warning math. Multiple warnings of the same dimension all show the same number — that's the dimension's contribution to the score deduction. This is honest: the score is per-dimension capped (color clashes cap at -40 regardless of count), so attributing fractionally would be phantom math.

### Backend refactor

- Extracted `_score_breakdown(items, base_item) -> dict[str, int]` — single source of truth for per-dimension penalties.
- `calculate_cohesion_score` is now a thin wrapper that sums the breakdown.
- `validate_outfit` calls the same helper to get the breakdown, then attaches each dimension's penalty to the warnings it generates.
- Dedup key is now `(message, category)` instead of just `message` — defensive in case the same message ever appears under different categories.

### What it doesn't change

- Score values are unchanged. Same formulas, same caps, same totals.
- Composition warnings (over-max items, missing categories, accessory cap, outerwear cap, duplicate singletons) still don't move the score — they show as "style note" instead of pts. Per PR #51's design, they still downgrade the verdict via `get_verdict`'s no-warnings gate.

## Test plan

- [x] Backend: 200 tests passing (1 new `test_validate_outfit_warnings_carry_category_and_score_impact`)
- [x] Test assertions updated from `w in warnings` / `"X" in w.lower()` to `w.message` / `w.category`
- [x] Frontend: `tsc --noEmit` clean
- [x] Frontend: lint at 13-issue baseline
- [ ] Manual: build an outfit with a known color clash → "Color may clash" warning shows "-10 pts"
- [ ] Manual: spread formality 1.0 → 5.0 across items → formality warning shows "-30 pts"
- [ ] Manual: outfit with no shared aesthetics → "No shared aesthetic tags" shows "-30 pts"
- [ ] Manual: composition warnings (when reached via direct API) show "style note", not pts
- [ ] Manual: the `Notes` section in both SummaryStep and OutfitDetailModal renders the per-warning suffix without breaking the existing layout

## Combined with #55

- #55 stops the spurious "Too many outerwear" warning from firing when base is Outerwear.
- #56 makes every warning that DOES fire tell the user its point cost.

Together: a sub-100 cohesion score is now both accurate and self-explanatory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)