### PR TITLE
build(extension): resolve build config from env files

### DIFF
--- a/extension/.env.example
+++ b/extension/.env.example
@@ -1,0 +1,15 @@
+# Extension build-time configuration.
+#
+# Copy to `.env` (gitignored) to override the build defaults. By default the
+# build also reads ../frontend/.env.local and maps NEXT_PUBLIC_* → SIY_*, so in
+# local dev you usually do NOT need this file at all.
+#
+# Precedence (later wins): defaults < frontend/.env.local < extension/.env < shell env.
+#
+# The Supabase ANON key is a public client key — safe to bundle. NEVER put the
+# Supabase service-role key here.
+
+SIY_API_BASE_URL=http://localhost:8000
+SIY_WEB_APP_URL=http://localhost:3000
+SIY_SUPABASE_URL=https://your-project.supabase.co
+SIY_SUPABASE_ANON_KEY=your-anon-key

--- a/extension/.gitignore
+++ b/extension/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 dist/
 *.log
+.env
+.env.local

--- a/extension/build.mjs
+++ b/extension/build.mjs
@@ -8,9 +8,16 @@
  *   dist/popup.html         (copied)
  *   dist/manifest.json      (copied)
  *
- * Configuration (API + Supabase endpoints) is injected at build time via env
- * vars so no values are hard-coded into source. The Supabase ANON key is a
- * public client key — safe to bundle. NEVER put the service-role key here.
+ * Configuration (API + Supabase endpoints) is injected at build time so no
+ * values are hard-coded into source. The Supabase ANON key is a public client
+ * key — safe to bundle. NEVER put the service-role key here.
+ *
+ * Config is resolved with this precedence (later overrides earlier):
+ *   1. Built-in dev defaults (localhost).
+ *   2. ../frontend/.env.local, mapping NEXT_PUBLIC_* → SIY_* so a plain build
+ *      automatically reuses the web app's local Supabase config.
+ *   3. ./.env (SIY_* keys) — extension-specific overrides, gitignored.
+ *   4. process.env (SIY_* set on the command line) — wins, for CI/one-offs.
  *
  * Usage:
  *   npm run build
@@ -19,7 +26,7 @@
  *   SIY_SUPABASE_URL=... SIY_SUPABASE_ANON_KEY=... npm run build
  */
 import * as esbuild from 'esbuild'
-import { rmSync, mkdirSync, copyFileSync, existsSync } from 'node:fs'
+import { rmSync, mkdirSync, copyFileSync, existsSync, readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'node:path'
 
@@ -27,15 +34,81 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const dist = resolve(__dirname, 'dist')
 const watch = process.argv.includes('--watch')
 
-const env = {
-  __SIY_API_BASE_URL__: process.env.SIY_API_BASE_URL || 'http://localhost:8000',
-  __SIY_WEB_APP_URL__: process.env.SIY_WEB_APP_URL || 'http://localhost:3000',
-  __SIY_SUPABASE_URL__: process.env.SIY_SUPABASE_URL || 'https://your-project.supabase.co',
-  __SIY_SUPABASE_ANON_KEY__: process.env.SIY_SUPABASE_ANON_KEY || 'your-anon-key',
+/** Minimal .env parser: `KEY=value`, ignores blanks/comments, strips quotes. */
+function parseEnvFile(path) {
+  if (!existsSync(path)) return {}
+  const out = {}
+  for (const line of readFileSync(path, 'utf8').split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith('#')) continue
+    const eq = trimmed.indexOf('=')
+    if (eq === -1) continue
+    const key = trimmed.slice(0, eq).trim()
+    let value = trimmed.slice(eq + 1).trim()
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1)
+    }
+    out[key] = value
+  }
+  return out
+}
+
+const stripSlash = (v) => (typeof v === 'string' ? v.replace(/\/+$/, '') : v)
+const firstDefined = (...vals) => vals.find((v) => v !== undefined && v !== '')
+
+const defaults = {
+  SIY_API_BASE_URL: 'http://localhost:8000',
+  SIY_WEB_APP_URL: 'http://localhost:3000',
+  SIY_SUPABASE_URL: 'https://your-project.supabase.co',
+  SIY_SUPABASE_ANON_KEY: 'your-anon-key',
+}
+
+// Reuse the web app's local config so `npm run build` "just works" in dev.
+const frontendEnv = parseEnvFile(resolve(__dirname, '../frontend/.env.local'))
+const fromFrontend = {
+  SIY_API_BASE_URL: frontendEnv.NEXT_PUBLIC_API_URL,
+  SIY_SUPABASE_URL: frontendEnv.NEXT_PUBLIC_SUPABASE_URL,
+  SIY_SUPABASE_ANON_KEY: frontendEnv.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+}
+
+// Extension-specific overrides (gitignored).
+const extensionEnv = parseEnvFile(resolve(__dirname, '.env'))
+
+const resolveKey = (key) =>
+  firstDefined(process.env[key], extensionEnv[key], fromFrontend[key], defaults[key])
+
+const config = {
+  __SIY_API_BASE_URL__: stripSlash(resolveKey('SIY_API_BASE_URL')),
+  __SIY_WEB_APP_URL__: stripSlash(resolveKey('SIY_WEB_APP_URL')),
+  __SIY_SUPABASE_URL__: stripSlash(resolveKey('SIY_SUPABASE_URL')),
+  __SIY_SUPABASE_ANON_KEY__: resolveKey('SIY_SUPABASE_ANON_KEY'),
+}
+
+// Surface the resolved config (without leaking the anon key) and loudly warn on
+// leftover placeholders — a placeholder Supabase URL breaks token refresh with a
+// "Failed to fetch" at runtime.
+console.log('[siy-extension] resolved config:')
+console.log(`  API_BASE_URL = ${config.__SIY_API_BASE_URL__}`)
+console.log(`  WEB_APP_URL  = ${config.__SIY_WEB_APP_URL__}`)
+console.log(`  SUPABASE_URL = ${config.__SIY_SUPABASE_URL__}`)
+console.log(
+  `  SUPABASE_ANON_KEY = ${config.__SIY_SUPABASE_ANON_KEY__ === defaults.SIY_SUPABASE_ANON_KEY ? '(placeholder)' : `set (${config.__SIY_SUPABASE_ANON_KEY__.length} chars)`}`,
+)
+if (
+  config.__SIY_SUPABASE_URL__ === defaults.SIY_SUPABASE_URL ||
+  config.__SIY_SUPABASE_ANON_KEY__ === defaults.SIY_SUPABASE_ANON_KEY
+) {
+  console.warn(
+    '[siy-extension] WARNING: Supabase config is still a placeholder. Auth/token refresh will fail at runtime.\n' +
+      '  Set SIY_SUPABASE_URL / SIY_SUPABASE_ANON_KEY (via env, extension/.env, or frontend/.env.local).',
+  )
 }
 
 const define = Object.fromEntries(
-  Object.entries(env).map(([k, v]) => [k, JSON.stringify(v)]),
+  Object.entries(config).map(([k, v]) => [k, JSON.stringify(v)]),
 )
 // Compile React in production mode (drops dev warnings, enables minification
 // to dead-code-eliminate them) unless we're in watch/dev mode.


### PR DESCRIPTION
A plain `npm run build` previously baked placeholder Supabase config into the bundle, so token refresh hit a non-existent host and every action failed at runtime with "Failed to fetch".

build.mjs now resolves each SIY_* value with precedence (later wins):
  defaults < frontend/.env.local (NEXT_PUBLIC_* mapped) < extension/.env < shell env

so local dev reuses the web app's Supabase config automatically. URL values are normalized (trailing slash stripped) and the build logs the resolved config (anon key length only, never the value) and loudly warns if any placeholder remains.

Add extension/.env.example documenting the SIY_* vars; gitignore real .env / .env.local so secrets can't be committed.