### PR TITLE
feat(extension): product image picker + color eyedropper

### DIFF
--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -316,6 +316,13 @@ class AnalyzeProductResponse(BaseModel):
     price: Optional[float] = None
     title: Optional[str] = None
     image_url: Optional[str] = None
+    preview_image: Optional[str] = Field(
+        None,
+        description=(
+            "Downscaled same-origin data: URL of the product image for "
+            "client-side eyedropping; None if unavailable."
+        ),
+    )
     source_url: str
     source_platform: Optional[str] = Field(None, description="e.g. zara, ssense, shopify, unknown")
 

--- a/backend/app/routers/extension.py
+++ b/backend/app/routers/extension.py
@@ -37,6 +37,7 @@ from app.services.product_analysis import (
     guess_aesthetics,
     guess_category,
     guess_formality,
+    make_preview_data_url,
 )
 from app.services.remote_image import RemoteImageError, fetch_remote_image
 
@@ -96,12 +97,14 @@ async def analyze_product(
 ) -> AnalyzeProductResponse:
     """Suggest closet metadata for a scraped product."""
     color = None
+    preview = None
     if request.image_url:
         # Color analysis is best-effort: a fetch/decode failure should NOT block
         # the rest of the suggestions — the user can still pick a color manually.
         try:
             image_bytes, _ = await fetch_remote_image(request.image_url)
             color = extract_dominant_color(image_bytes)
+            preview = make_preview_data_url(image_bytes)
         except RemoteImageError as exc:
             logger.info(f"analyze-product: image unusable ({exc})")
         except Exception as exc:  # noqa: BLE001
@@ -120,6 +123,7 @@ async def analyze_product(
         price=request.price,
         title=request.title,
         image_url=request.image_url,
+        preview_image=preview,
         source_url=request.page_url,
         source_platform=detect_platform(request.page_url),
     )

--- a/backend/app/services/product_analysis.py
+++ b/backend/app/services/product_analysis.py
@@ -9,11 +9,12 @@ in-app uploads.
 
 from __future__ import annotations
 
+import base64
 import io
 import logging
 from urllib.parse import urlparse
 
-from PIL import Image
+from PIL import Image, ImageOps
 
 from app.models.schemas import Category, Color, HSL
 from app.services.color_harmony import get_color_name_from_hsl, is_neutral_color
@@ -112,6 +113,28 @@ def extract_dominant_color(image_bytes: bytes) -> Color | None:
         name=name,
         is_neutral=is_neutral_color(name),
     )
+
+
+def make_preview_data_url(image_bytes: bytes, max_dim: int = 512) -> str | None:
+    """Downscale already-fetched image bytes into a same-origin JPEG ``data:``
+    URL for client-side eyedropping in the extension popup.
+
+    A ``data:`` URL is same-origin to the popup, so a canvas drawn from it is
+    NOT tainted and ``getImageData`` works — unlike the remote image URL.
+    Best-effort: returns ``None`` on any decode/encode failure.
+    """
+    try:
+        with Image.open(io.BytesIO(image_bytes)) as img:
+            oriented = ImageOps.exif_transpose(img)
+            rgb = oriented.convert("RGB")
+            rgb.thumbnail((max_dim, max_dim))
+            buf = io.BytesIO()
+            rgb.save(buf, format="JPEG", quality=80)
+        encoded = base64.b64encode(buf.getvalue()).decode("ascii")
+        return f"data:image/jpeg;base64,{encoded}"
+    except Exception as exc:  # noqa: BLE001 — best-effort preview
+        logger.info(f"Preview generation failed: {exc!r}")
+        return None
 
 
 # =============================================================================

--- a/backend/tests/unit/test_product_preview.py
+++ b/backend/tests/unit/test_product_preview.py
@@ -1,0 +1,31 @@
+import base64
+import io
+
+from PIL import Image
+
+from app.services.product_analysis import make_preview_data_url
+
+
+def _png_bytes(w: int = 1000, h: int = 1200, color: tuple = (80, 90, 160)) -> bytes:
+    img = Image.new("RGB", (w, h), color)
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def test_returns_jpeg_data_url():
+    data_url = make_preview_data_url(_png_bytes())
+    assert data_url is not None
+    assert data_url.startswith("data:image/jpeg;base64,")
+
+
+def test_downscales_to_max_dim():
+    data_url = make_preview_data_url(_png_bytes(1000, 1200), max_dim=512)
+    assert data_url is not None
+    raw = base64.b64decode(data_url.split(",", 1)[1])
+    with Image.open(io.BytesIO(raw)) as img:
+        assert max(img.size) <= 512
+
+
+def test_returns_none_on_garbage():
+    assert make_preview_data_url(b"not an image") is None

--- a/extension/src/lib/api.ts
+++ b/extension/src/lib/api.ts
@@ -44,12 +44,17 @@ async function authedFetch<T>(path: string, init: RequestInit): Promise<T> {
   return (await response.json()) as T
 }
 
-export function analyzeProduct(raw: RawProduct): Promise<AnalyzeResponse> {
+export function analyzeProduct(
+  raw: RawProduct,
+  imageUrl?: string | null,
+  signal?: AbortSignal,
+): Promise<AnalyzeResponse> {
   return authedFetch<AnalyzeResponse>('/api/extension/analyze-product', {
     method: 'POST',
+    signal,
     body: JSON.stringify({
       page_url: raw.url,
-      image_url: raw.image,
+      image_url: imageUrl ?? raw.images[0] ?? raw.image,
       title: raw.title,
       price: raw.price,
       brand: raw.brand,

--- a/extension/src/lib/color.ts
+++ b/extension/src/lib/color.ts
@@ -72,3 +72,131 @@ export const COLOR_PALETTE: Color[] = [
   ['#5B4B8A', 'purple'],
   ['#B5651D', 'orange'],
 ].map(([hex, name]) => colorFromHex(hex, name))
+
+// ---------------------------------------------------------------------------
+// Hue-based naming — hand-mirrored from frontend/src/lib/colorUtils.ts so an
+// eyedropped pixel is named consistently with the web app's in-app picker.
+// (Backend auto-detection uses color_harmony — a different namer — so the
+// initial suggested color and an eyedropped value can use different names.)
+// ---------------------------------------------------------------------------
+
+const NEUTRAL_COLOR_DATA: Record<string, HSL> = {
+  black: { h: 0, s: 0, l: 0 },
+  white: { h: 0, s: 0, l: 100 },
+  gray: { h: 0, s: 0, l: 50 },
+  navy: { h: 210, s: 61, l: 11 },
+  beige: { h: 60, s: 56, l: 91 },
+  cream: { h: 57, s: 100, l: 91 },
+  tan: { h: 34, s: 44, l: 69 },
+  khaki: { h: 37, s: 29, l: 67 },
+}
+
+const COLOR_NAMES: Array<{ name: string; hue: [number, number]; satMin: number }> = [
+  { name: 'Red', hue: [0, 15], satMin: 20 },
+  { name: 'Red', hue: [345, 360], satMin: 20 },
+  { name: 'Orange', hue: [15, 45], satMin: 20 },
+  { name: 'Yellow', hue: [45, 65], satMin: 20 },
+  { name: 'Lime', hue: [65, 80], satMin: 20 },
+  { name: 'Green', hue: [80, 160], satMin: 20 },
+  { name: 'Teal', hue: [160, 190], satMin: 20 },
+  { name: 'Cyan', hue: [190, 210], satMin: 20 },
+  { name: 'Blue', hue: [210, 250], satMin: 20 },
+  { name: 'Indigo', hue: [250, 270], satMin: 20 },
+  { name: 'Purple', hue: [270, 290], satMin: 20 },
+  { name: 'Magenta', hue: [290, 320], satMin: 20 },
+  { name: 'Pink', hue: [320, 345], satMin: 20 },
+]
+
+function rgbToHsl(r: number, g: number, b: number): HSL {
+  r /= 255
+  g /= 255
+  b /= 255
+  const max = Math.max(r, g, b)
+  const min = Math.min(r, g, b)
+  let h = 0
+  let s = 0
+  const l = (max + min) / 2
+  if (max !== min) {
+    const d = max - min
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min)
+    switch (max) {
+      case r:
+        h = ((g - b) / d + (g < b ? 6 : 0)) / 6
+        break
+      case g:
+        h = ((b - r) / d + 2) / 6
+        break
+      default:
+        h = ((r - g) / d + 4) / 6
+    }
+  }
+  return { h: Math.round(h * 360), s: Math.round(s * 100), l: Math.round(l * 100) }
+}
+
+function rgbToHex(r: number, g: number, b: number): string {
+  const toHex = (n: number) => {
+    const h = Math.round(Math.max(0, Math.min(255, n))).toString(16)
+    return h.length === 1 ? '0' + h : h
+  }
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`.toUpperCase()
+}
+
+function colorDistance(a: HSL, b: HSL): number {
+  let hueDiff = Math.abs(a.h - b.h)
+  if (hueDiff > 180) hueDiff = 360 - hueDiff
+  return hueDiff * 0.5 + Math.abs(a.s - b.s) * 1.5 + Math.abs(a.l - b.l) * 2
+}
+
+function findClosestNeutral(hsl: HSL): { name: string; distance: number } | null {
+  let closest: { name: string; distance: number } | null = null
+  for (const [name, data] of Object.entries(NEUTRAL_COLOR_DATA)) {
+    const distance = colorDistance(hsl, data)
+    if (distance < 40 && (!closest || distance < closest.distance)) {
+      closest = { name, distance }
+    }
+  }
+  return closest
+}
+
+export function getColorName(hsl: HSL): { name: string; isNeutral: boolean } {
+  const closest = findClosestNeutral(hsl)
+  if (closest && closest.distance < 30) {
+    return {
+      name: closest.name.charAt(0).toUpperCase() + closest.name.slice(1),
+      isNeutral: true,
+    }
+  }
+  if (hsl.s < 10) {
+    if (hsl.l < 20) return { name: 'Black', isNeutral: true }
+    if (hsl.l > 85) return { name: 'White', isNeutral: true }
+    return { name: 'Gray', isNeutral: true }
+  }
+  let baseName = 'Gray'
+  for (const c of COLOR_NAMES) {
+    if (hsl.h >= c.hue[0] && hsl.h < c.hue[1] && hsl.s >= c.satMin) {
+      baseName = c.name
+      break
+    }
+  }
+  let modifier = ''
+  if (hsl.l < 25) modifier = 'Dark '
+  else if (hsl.l < 40) modifier = 'Deep '
+  else if (hsl.l > 75) modifier = 'Light '
+  else if (hsl.l > 60) modifier = 'Pale '
+  if (hsl.s < 30 && hsl.s >= 10) modifier = 'Muted ' + modifier
+  return { name: (modifier + baseName).trim(), isNeutral: false }
+}
+
+/** Build a full Color from a sampled RGB pixel (eyedropper). */
+export function colorFromRgb(r: number, g: number, b: number): Color {
+  const hsl = rgbToHsl(r, g, b)
+  const { name, isNeutral } = getColorName(hsl)
+  return { hex: rgbToHex(r, g, b), hsl, name, is_neutral: isNeutral }
+}
+
+/** Build a full Color from a hex string (manual fallback input). */
+export function buildColorFromHex(hex: string): Color {
+  const hsl = hexToHsl(hex)
+  const { name, isNeutral } = getColorName(hsl)
+  return { hex: hex.toUpperCase(), hsl, name, is_neutral: isNeutral }
+}

--- a/extension/src/lib/productExtractor.ts
+++ b/extension/src/lib/productExtractor.ts
@@ -5,20 +5,25 @@
  *   1. JSON-LD `Product` schema
  *   2. Open Graph / product meta tags
  *   3. Common ecommerce DOM selectors
- *   4. Largest visible image fallback
+ *   4. Largest visible images fallback
  *   5. Current page URL as source_url
  *
- * Everything is defensive — any individual layer may throw or return junk on a
- * random page, so each is wrapped and merged by precedence.
+ * Each layer contributes a LIST of candidate image URLs; they are merged in
+ * precedence order, absolutized, deduped, ranked (junk last), and capped so the
+ * popup can offer an image picker. `image` is kept as `images[0]` for
+ * back-compat. Everything is defensive — any individual layer may throw or
+ * return junk on a random page, so each is wrapped and merged by precedence.
  */
 import type { RawProduct } from './types'
 
 interface PartialProduct {
   title?: string | null
-  image?: string | null
+  images?: string[]
   price?: number | null
   brand?: string | null
 }
+
+const MAX_CANDIDATES = 8
 
 export function extractProduct(): RawProduct {
   const url = window.location.href
@@ -27,17 +32,26 @@ export function extractProduct(): RawProduct {
   const og = safe(extractFromMetaTags)
   const dom = safe(extractFromSelectors)
 
-  const title =
-    jsonLd.title || og.title || dom.title || document.title || null
-  const image = absolutize(
-    jsonLd.image || og.image || dom.image || largestImage(),
-  )
+  const title = jsonLd.title || og.title || dom.title || document.title || null
   const price = firstNumber([jsonLd.price, og.price, dom.price])
   const brand = jsonLd.brand || og.brand || dom.brand || null
 
+  // Merge image candidates in precedence order, absolutize, dedupe, rank, cap.
+  const candidates = [
+    ...(jsonLd.images ?? []),
+    ...(og.images ?? []),
+    ...(dom.images ?? []),
+    ...largeImages(),
+  ]
+    .map(absolutize)
+    .filter((u): u is string => !!u)
+
+  const images = rankImages(dedupeImages(candidates)).slice(0, MAX_CANDIDATES)
+
   return {
     title: clean(title),
-    image,
+    images,
+    image: images[0] ?? null,
     price,
     brand: clean(brand),
     url,
@@ -65,7 +79,7 @@ function extractFromJsonLd(): PartialProduct {
     if (product) {
       return {
         title: asString(product.name),
-        image: pickImage(product.image),
+        images: collectImages(product.image),
         price: pickOfferPrice(product.offers),
         brand: pickBrand(product.brand),
       }
@@ -101,14 +115,17 @@ function findProductNode(node: unknown): JsonObject | null {
   return isProduct ? obj : null
 }
 
-function pickImage(image: unknown): string | null {
-  if (!image) return null
-  if (typeof image === 'string') return image
-  if (Array.isArray(image)) return pickImage(image[0])
+/** Flatten every image URL from a JSON-LD `image` value (string / array / ImageObject). */
+function collectImages(image: unknown): string[] {
+  if (!image) return []
+  if (typeof image === 'string') return [image]
+  if (Array.isArray(image)) return image.flatMap(collectImages)
   if (typeof image === 'object') {
-    return asString((image as JsonObject).url)
+    const obj = image as JsonObject
+    if (typeof obj.url === 'string') return [obj.url]
+    if (Array.isArray(obj['@list'])) return collectImages(obj['@list'])
   }
-  return null
+  return []
 }
 
 function pickOfferPrice(offers: unknown): number | null {
@@ -147,10 +164,11 @@ function pickBrand(brand: unknown): string | null {
 function extractFromMetaTags(): PartialProduct {
   return {
     title: meta('og:title') || meta('twitter:title'),
-    image:
-      meta('og:image:secure_url') ||
-      meta('og:image') ||
-      meta('twitter:image'),
+    images: [
+      ...metaAll('og:image:secure_url'),
+      ...metaAll('og:image'),
+      ...metaAll('twitter:image'),
+    ],
     price: toNumber(
       meta('product:price:amount') ||
         meta('og:price:amount') ||
@@ -165,6 +183,13 @@ function meta(property: string): string | null {
     document.querySelector(`meta[property="${property}"]`) ||
     document.querySelector(`meta[name="${property}"]`)
   return el?.getAttribute('content') || null
+}
+
+function metaAll(property: string): string[] {
+  const sel = `meta[property="${property}"], meta[name="${property}"]`
+  return Array.from(document.querySelectorAll(sel))
+    .map((el) => el.getAttribute('content') || '')
+    .filter(Boolean)
 }
 
 // ---------------------------------------------------------------------------
@@ -207,7 +232,7 @@ const IMAGE_SELECTORS = [
 function extractFromSelectors(): PartialProduct {
   return {
     title: textFrom(TITLE_SELECTORS),
-    image: imgFrom(IMAGE_SELECTORS),
+    images: imgsFrom(IMAGE_SELECTORS),
     price: toNumber(textFrom(PRICE_SELECTORS)),
     brand: textFrom(BRAND_SELECTORS),
   }
@@ -224,37 +249,122 @@ function textFrom(selectors: string[]): string | null {
   return null
 }
 
-function imgFrom(selectors: string[]): string | null {
+function imgsFrom(selectors: string[]): string[] {
+  const out: string[] = []
   for (const selector of selectors) {
-    const el = document.querySelector(selector)
-    if (!el) continue
-    const src =
-      el.getAttribute('content') ||
+    for (const el of Array.from(document.querySelectorAll(selector))) {
+      const url = bestImgUrl(el)
+      if (url) out.push(url)
+    }
+  }
+  return out
+}
+
+function bestImgUrl(el: Element): string | null {
+  // <img>: prefer the rendered currentSrc, then the largest srcset variant,
+  // then src/data-src. Non-img (e.g. meta[itemprop=image]): content/src.
+  if (el instanceof HTMLImageElement) {
+    const fromSrcset = largestFromSrcset(el.getAttribute('srcset'))
+    return validImg(
+      el.currentSrc ||
+        fromSrcset ||
+        el.getAttribute('src') ||
+        el.getAttribute('data-src') ||
+        '',
+    )
+  }
+  return validImg(
+    el.getAttribute('content') ||
       el.getAttribute('src') ||
       el.getAttribute('data-src') ||
-      ''
-    if (src && !src.startsWith('data:')) return src
+      '',
+  )
+}
+
+function validImg(src: string): string | null {
+  if (!src) return null
+  if (src.startsWith('data:') || src.startsWith('blob:')) return null
+  return src
+}
+
+function largestFromSrcset(srcset: string | null): string | null {
+  if (!srcset) return null
+  // "url1 320w, url2 640w" or "url1 1x, url2 2x" — pick the largest descriptor.
+  let best: { url: string; size: number } | null = null
+  for (const part of srcset.split(',')) {
+    const [url, descriptor] = part.trim().split(/\s+/)
+    if (!url) continue
+    const size = descriptor ? parseFloat(descriptor) : 1
+    const n = Number.isFinite(size) ? size : 1
+    if (!best || n > best.size) best = { url, size: n }
   }
-  return null
+  return best?.url ?? null
 }
 
 // ---------------------------------------------------------------------------
-// Layer 4 — largest visible image fallback
+// Layer 4 — largest visible images fallback
 // ---------------------------------------------------------------------------
 
-function largestImage(): string | null {
-  let best: { src: string; area: number } | null = null
-
+function largeImages(): string[] {
+  const scored: { src: string; area: number }[] = []
   for (const img of Array.from(document.images)) {
     const src = img.currentSrc || img.src
-    if (!src || src.startsWith('data:')) continue
+    if (!src || src.startsWith('data:') || src.startsWith('blob:')) continue
     const rect = img.getBoundingClientRect()
     if (rect.width < 80 || rect.height < 80) continue
-    const area = (img.naturalWidth || rect.width) * (img.naturalHeight || rect.height)
-    if (!best || area > best.area) best = { src, area }
+    const nW = img.naturalWidth
+    const nH = img.naturalHeight
+    // Skip clearly-small intrinsic images; for not-yet-loaded lazy images (no
+    // intrinsic size) only trust the layout box if it is itself large, so a
+    // placeholder-sized box can't outrank a real full-res photo.
+    if (nW && nW < 200) continue
+    if (nH && nH < 200) continue
+    if (!nW && !nH && (rect.width < 200 || rect.height < 200)) continue
+    const w = nW || rect.width
+    const h = nH || rect.height
+    scored.push({ src, area: w * h })
   }
+  scored.sort((a, b) => b.area - a.area)
+  return scored.map((s) => s.src)
+}
 
-  return best?.src ?? null
+// ---------------------------------------------------------------------------
+// candidate merging
+// ---------------------------------------------------------------------------
+
+const JUNK_PATH = /(logo|icon|sprite|thumb|placeholder|favicon|spinner|loading)/i
+
+function normalizeForDedupe(url: string): string {
+  try {
+    const u = new URL(url)
+    u.hash = ''
+    // Collapse common CDN resize/crop params so resolution variants merge.
+    for (const p of ['w', 'width', 'h', 'height', 'q', 'quality', 'crop', 'fit', 'dpr', 'sw', 'sh']) {
+      u.searchParams.delete(p)
+    }
+    return u.origin + u.pathname + u.search
+  } catch {
+    return url
+  }
+}
+
+function dedupeImages(urls: string[]): string[] {
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const url of urls) {
+    const key = normalizeForDedupe(url)
+    if (seen.has(key)) continue
+    seen.add(key)
+    out.push(url)
+  }
+  return out
+}
+
+/** Stable ranking: keep precedence order, push likely-junk URLs to the back. */
+function rankImages(urls: string[]): string[] {
+  const good = urls.filter((u) => !JUNK_PATH.test(u))
+  const suspect = urls.filter((u) => JUNK_PATH.test(u))
+  return [...good, ...suspect]
 }
 
 // ---------------------------------------------------------------------------

--- a/extension/src/lib/types.ts
+++ b/extension/src/lib/types.ts
@@ -28,6 +28,9 @@ export type Ownership = 'owned' | 'wishlist'
 /** Raw product context scraped from the current page. */
 export interface RawProduct {
   title: string | null
+  /** Ranked candidate image URLs (best-first); may be empty. */
+  images: string[]
+  /** Back-compat alias = images[0] ?? null. */
   image: string | null
   price: number | null
   brand: string | null
@@ -44,6 +47,7 @@ export interface AnalyzeResponse {
   price: number | null
   title: string | null
   image_url: string | null
+  preview_image: string | null
   source_url: string
   source_platform: string | null
 }

--- a/extension/src/popup/ImageEyedropper.tsx
+++ b/extension/src/popup/ImageEyedropper.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useRef, useState } from 'react'
+import { colorFromRgb } from '../lib/color'
+import type { Color } from '../lib/types'
+
+interface Props {
+  previewSrc: string
+  currentHex: string
+  onPick: (color: Color) => void
+}
+
+/**
+ * Draws a backend-relayed (same-origin data:) image to a canvas and samples
+ * the pixel under the cursor. MUST be fed the data: URL only — drawing a
+ * remote cross-origin image would taint the canvas and break getImageData.
+ */
+export function ImageEyedropper({ previewSrc, currentHex, onPick }: Props) {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const [ready, setReady] = useState(false)
+  const [dragging, setDragging] = useState(false)
+  const [marker, setMarker] = useState<{ x: number; y: number } | null>(null)
+
+  // Draw at intrinsic size so the backing store is 1:1 with source pixels.
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    setReady(false)
+    const img = new Image()
+    img.onload = () => {
+      canvas.width = img.naturalWidth
+      canvas.height = img.naturalHeight
+      const ctx = canvas.getContext('2d')
+      if (!ctx) return
+      ctx.drawImage(img, 0, 0)
+      setReady(true)
+    }
+    img.src = previewSrc
+  }, [previewSrc])
+
+  const sample = (clientX: number, clientY: number) => {
+    const canvas = canvasRef.current
+    if (!canvas || !ready) return
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+    const rect = canvas.getBoundingClientRect()
+    // Map by normalized fraction → DPR-independent (backing store == source px).
+    const xNorm = Math.max(0, Math.min(1, (clientX - rect.left) / rect.width))
+    const yNorm = Math.max(0, Math.min(1, (clientY - rect.top) / rect.height))
+    setMarker({ x: xNorm, y: yNorm })
+    const px = Math.floor(xNorm * canvas.width)
+    const py = Math.floor(yNorm * canvas.height)
+    const sx = Math.max(0, Math.min(canvas.width - 5, px - 2))
+    const sy = Math.max(0, Math.min(canvas.height - 5, py - 2))
+    try {
+      const { data } = ctx.getImageData(sx, sy, 5, 5)
+      let r = 0
+      let g = 0
+      let b = 0
+      let n = 0
+      for (let i = 0; i < data.length; i += 4) {
+        if (data[i + 3] < 16) continue // skip (near-)transparent pixels
+        r += data[i]
+        g += data[i + 1]
+        b += data[i + 2]
+        n++
+      }
+      if (n === 0) return
+      onPick(colorFromRgb(Math.round(r / n), Math.round(g / n), Math.round(b / n)))
+    } catch {
+      /* canvas unreadable — ignore */
+    }
+  }
+
+  useEffect(() => {
+    if (!dragging) return
+    const move = (e: MouseEvent) => sample(e.clientX, e.clientY)
+    const up = () => setDragging(false)
+    document.addEventListener('mousemove', move)
+    document.addEventListener('mouseup', up)
+    return () => {
+      document.removeEventListener('mousemove', move)
+      document.removeEventListener('mouseup', up)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dragging, ready])
+
+  return (
+    <div className="eyedropper">
+      <canvas
+        ref={canvasRef}
+        className="eyedropper__canvas"
+        onMouseDown={(e) => {
+          setDragging(true)
+          sample(e.clientX, e.clientY)
+        }}
+      />
+      {marker && (
+        <span
+          className="eyedropper__marker"
+          style={{ left: `${marker.x * 100}%`, top: `${marker.y * 100}%`, background: currentHex }}
+          aria-hidden="true"
+        />
+      )}
+    </div>
+  )
+}

--- a/extension/src/popup/Popup.tsx
+++ b/extension/src/popup/Popup.tsx
@@ -63,7 +63,9 @@ export function Popup() {
       setPhase('analyzing')
       const analysis = await analyzeProduct(raw)
       setForm({
-        color: analysis.color ?? COLOR_PALETTE[0],
+        // Re-name the detected color with the client namer (same as the
+        // eyedropper) so tans/khakis don't show the backend's coarse "orange".
+        color: analysis.color ? buildColorFromHex(analysis.color.hex) : COLOR_PALETTE[0],
         categoryL1: analysis.category.l1,
         categoryL2: analysis.category.l2,
         formality: clampLevel(analysis.formality),

--- a/extension/src/popup/Popup.tsx
+++ b/extension/src/popup/Popup.tsx
@@ -1,9 +1,10 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import type { ReactNode } from 'react'
 import { CONNECT_PATH, WEB_APP_URL } from '../config'
 import { analyzeProduct, importItem, matchProduct } from '../lib/api'
 import { disconnect, isConnected, NotAuthenticatedError } from '../lib/auth'
-import { COLOR_PALETTE } from '../lib/color'
+import { ImageEyedropper } from './ImageEyedropper'
+import { buildColorFromHex, COLOR_PALETTE } from '../lib/color'
 import {
   AESTHETIC_TAGS,
   CATEGORY_L1,
@@ -26,6 +27,7 @@ interface FormState {
   price: string
   ownership: Ownership
   imageUrl: string | null
+  previewImage: string | null
   sourceUrl: string
   title: string | null
 }
@@ -42,6 +44,9 @@ export function Popup() {
   const [matchLoading, setMatchLoading] = useState(false)
   const [match, setMatch] = useState<MatchResponse | null>(null)
   const [actionError, setActionError] = useState('')
+  const [recoloring, setRecoloring] = useState(false)
+  const selectionSeq = useRef(0)
+  const analyzeAbort = useRef<AbortController | null>(null)
 
   const init = useCallback(async () => {
     setPhase('loading')
@@ -67,6 +72,7 @@ export function Popup() {
         price: analysis.price != null ? String(analysis.price) : '',
         ownership: 'owned',
         imageUrl: analysis.image_url ?? raw.image,
+        previewImage: analysis.preview_image ?? null,
         sourceUrl: analysis.source_url,
         title: analysis.title ?? raw.title,
       })
@@ -104,6 +110,11 @@ export function Popup() {
     if (!form) return
     if (!form.imageUrl) {
       setActionError('No product image found to import.')
+      return
+    }
+    if (!/^https?:/i.test(form.imageUrl)) {
+      // Never send a relayed data: preview to import-item (http/https only).
+      setActionError('Cannot import this image.')
       return
     }
     setSaving(true)
@@ -153,6 +164,45 @@ export function Popup() {
     }
   }, [form])
 
+  const handleSelectImage = useCallback(
+    async (url: string) => {
+      if (!product || !form || url === form.imageUrl) return
+      const prevUrl = form.imageUrl
+      const mySeq = ++selectionSeq.current
+      analyzeAbort.current?.abort()
+      const controller = new AbortController()
+      analyzeAbort.current = controller
+
+      setForm((prev) => (prev ? { ...prev, imageUrl: url } : prev))
+      setRecoloring(true)
+      setActionError('')
+      try {
+        const analysis = await analyzeProduct(product, url, controller.signal)
+        if (mySeq !== selectionSeq.current) return // superseded
+        setForm((prev) =>
+          prev
+            ? {
+                ...prev,
+                color: analysis.color ?? prev.color,
+                previewImage: analysis.preview_image ?? null,
+              }
+            : prev,
+        )
+        setMatch(null) // re-run match against the new color
+      } catch (err) {
+        if ((err as Error)?.name === 'AbortError') return
+        if (mySeq === selectionSeq.current) {
+          // revert the optimistic image so image + color can't desync
+          setForm((prev) => (prev ? { ...prev, imageUrl: prevUrl } : prev))
+          setActionError('Could not load that image.')
+        }
+      } finally {
+        if (mySeq === selectionSeq.current) setRecoloring(false)
+      }
+    },
+    [product, form],
+  )
+
   // Auto-run matching the first time the user opens the Match tab.
   useEffect(() => {
     if (view === 'match' && form && !match && !matchLoading) {
@@ -191,6 +241,15 @@ export function Popup() {
         {phase === 'ready' && form && product && (
           <>
             <ProductPreview imageUrl={form.imageUrl} title={form.title} sourceUrl={form.sourceUrl} />
+
+            {product.images.length > 1 && (
+              <ImageStrip
+                images={product.images}
+                selected={form.imageUrl}
+                busy={recoloring}
+                onSelect={handleSelectImage}
+              />
+            )}
 
             <div className="tabs">
               <button
@@ -291,6 +350,41 @@ function ProductPreview({
   )
 }
 
+function ImageStrip({
+  images,
+  selected,
+  busy,
+  onSelect,
+}: {
+  images: string[]
+  selected: string | null
+  busy: boolean
+  onSelect: (url: string) => void
+}) {
+  return (
+    <div className="filmstrip" aria-busy={busy}>
+      {images.map((url) => (
+        <button
+          key={url}
+          type="button"
+          className={`filmstrip__item ${url === selected ? 'is-active' : ''}`}
+          aria-pressed={url === selected}
+          onClick={() => onSelect(url)}
+        >
+          <img
+            src={url}
+            alt=""
+            onError={(e) => {
+              const parent = e.currentTarget.parentElement
+              if (parent) parent.style.display = 'none'
+            }}
+          />
+        </button>
+      ))}
+    </div>
+  )
+}
+
 function SavedScreen({
   ownership,
   onAddAnother,
@@ -331,7 +425,6 @@ function AddForm({
     setForm((prev) => (prev ? { ...prev, ...patch } : prev))
 
   const l2Options = CATEGORY_TAXONOMY[form.categoryL1] ?? []
-  const palette = withDetectedColor(form.color)
 
   const toggleAesthetic = (tag: string) => {
     const has = form.aesthetics.includes(tag)
@@ -378,18 +471,26 @@ function AddForm({
       </Field>
 
       <Field label={`Color · ${form.color.name}`}>
-        <div className="swatches">
-          {palette.map((c) => (
-            <button
-              key={c.hex}
-              className={`swatch ${c.hex === form.color.hex ? 'active' : ''}`}
-              style={{ background: c.hex }}
-              title={c.name}
-              aria-label={c.name}
-              onClick={() => update({ color: c })}
+        {form.previewImage ? (
+          <>
+            <ImageEyedropper
+              previewSrc={form.previewImage}
+              currentHex={form.color.hex}
+              onPick={(c) => update({ color: c })}
             />
-          ))}
-        </div>
+            <div className="colorout">
+              <span
+                className="colorout__sw"
+                style={{ background: form.color.hex }}
+                aria-hidden="true"
+              />
+              <span className="colorout__name">{form.color.name}</span>
+              <span className="hex">{form.color.hex}</span>
+            </div>
+          </>
+        ) : (
+          <HexFallback color={form.color} onChange={(c) => update({ color: c })} />
+        )}
       </Field>
 
       <Field label="Formality">
@@ -577,7 +678,29 @@ function parsePrice(value: string): number | null {
   return Number.isFinite(n) && n >= 0 ? n : null
 }
 
-function withDetectedColor(detected: Color): Color[] {
-  if (COLOR_PALETTE.some((c) => c.hex === detected.hex)) return COLOR_PALETTE
-  return [detected, ...COLOR_PALETTE]
+function HexFallback({
+  color,
+  onChange,
+}: {
+  color: Color
+  onChange: (c: Color) => void
+}) {
+  const [text, setText] = useState(color.hex)
+  useEffect(() => setText(color.hex), [color.hex])
+  return (
+    <div className="colorout">
+      <span className="colorout__sw" style={{ background: color.hex }} aria-hidden="true" />
+      <input
+        className="text-input"
+        value={text}
+        placeholder="#000000"
+        maxLength={7}
+        onChange={(e) => {
+          const v = e.target.value.toUpperCase()
+          setText(v)
+          if (/^#[0-9A-F]{6}$/.test(v)) onChange(buildColorFromHex(v))
+        }}
+      />
+    </div>
+  )
 }

--- a/extension/src/popup/popup.css
+++ b/extension/src/popup/popup.css
@@ -379,3 +379,79 @@ hr.rule {
     transform: rotate(360deg);
   }
 }
+
+/* ---- candidate image strip ---- */
+.filmstrip {
+  display: flex;
+  gap: 8px;
+  overflow-x: auto;
+  padding-bottom: 2px;
+}
+.filmstrip__item {
+  flex: 0 0 auto;
+  width: 48px;
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+.filmstrip__item img {
+  width: 48px;
+  height: 60px;
+  object-fit: cover;
+  border: 1px solid var(--ink);
+  background: var(--paper-2);
+  display: block;
+}
+.filmstrip__item.is-active img {
+  outline: 2px solid var(--ink);
+  outline-offset: 1px;
+}
+
+/* ---- eyedropper ---- */
+.eyedropper {
+  position: relative;
+  width: 100%;
+  max-width: 328px;
+}
+.eyedropper__canvas {
+  display: block;
+  width: 100%;
+  height: auto;
+  border: 1px solid var(--ink);
+  background: var(--paper-2);
+  cursor: crosshair;
+}
+.eyedropper__marker {
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  transform: translate(-50%, -50%);
+  border: 2px solid var(--paper);
+  pointer-events: none;
+}
+.colorout {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 8px;
+}
+.colorout__sw {
+  width: 40px;
+  height: 40px;
+  border: 1px solid var(--ink);
+}
+.colorout__name {
+  font-family: 'Instrument Serif', Georgia, serif;
+  font-style: italic;
+  font-size: 15px;
+  color: var(--ink-2);
+}
+.hex {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 14px;
+  letter-spacing: 0.06em;
+  color: var(--ink);
+  border-bottom: 1px solid var(--ink);
+  padding-bottom: 2px;
+}


### PR DESCRIPTION
## Why
The extension auto-picked one product image (often a cropped `og:image`) with no way to change it, and the color step only offered 12 fixed swatches — so the saved color was rarely the garment's true color.

## What
- **Image picker.** The extractor now returns a ranked list of candidate images (full JSON-LD gallery, all OG/Twitter tags, every DOM `<img>` via `currentSrc`/`srcset`, large images), deduped and capped at 8. A thumbnail strip lets you switch which image represents the item.
- **Color eyedropper.** The backend relays a downscaled (~512px) same-origin `data:` URL of the image it already fetched. The popup draws it to a canvas and you drag/click the garment to sample its true color (5×5 averaged, named client-side). A hex input is the fallback when no preview is available.
- Switching the image re-analyzes only its color, guarded by a sequence id + `AbortController` (no stale results) with optimistic rollback. Import always uses the original full-res URL — never the preview.

## How to test
1. `cd extension && npm run build`, then reload the unpacked `extension/dist` at `chrome://extensions`.
2. Open a product page with multiple images, open the popup.
3. **Strip:** click thumbnails — the preview swaps and the detected color updates.
4. **Eyedrop:** drag over the garment — the swatch, name, and hex update live.
5. **Import:** save and confirm the closet item stores the full image and the eyedropped color.
6. Backend: `pytest tests/unit/test_product_preview.py` → 3 pass.

## Notes
- No manifest/CSP or host-permission change (same `analyze-product` endpoint; `data:` canvas isn't tainted).
- The "image looks cut" display fix (`object-contain` in the detail modals) is intentionally **not** in this PR — pending confirmation of source-crop vs display-crop.
- 11 pre-existing unit failures (`supabase`/`gemini`/`tryon`/`outfits` mocks) are unrelated to this change.

## Screenshots / GIF
<!-- add a short GIF of switching images + eyedropping a color -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
